### PR TITLE
Refactor/mssm higgs

### DIFF
--- a/examples/sample2HDM.cpp
+++ b/examples/sample2HDM.cpp
@@ -35,14 +35,15 @@ int main()
     FeynOptions options;
     options.setTopology(Topology::Box);
     options.addFilter(filter::forceParticleCombination({"W", "t"}));
-    options.addFilter(filter::disableParticles({"u_L", "c_L", "H^+", "G^+"}));
+    options.addFilter(filter::disableParticles({"u_L", "c_L", "Hp", "Gp"}));
     options.setFermionOrder({3, 0, 1, 2});
     mty::option::keepOnlyFirstMassInLoop = true;
-    auto ampl                            = THDM.computeAmplitude(OneLoop,
+
+    auto ampl = THDM.computeAmplitude(OneLoop,
                                       {Incoming("d"),
-                                                                  Incoming(AntiPart("s")),
-                                                                  Outgoing(AntiPart("d")),
-                                                                  Outgoing("s")},
+                                       Incoming(AntiPart("s")),
+                                       Outgoing(AntiPart("d")),
+                                       Outgoing("s")},
                                       options);
     Display(ampl);
     Show(ampl);

--- a/examples/sampleElectroWeak.cpp
+++ b/examples/sampleElectroWeak.cpp
@@ -20,7 +20,7 @@ int main()
     Rename(ElectroWeak, "A_U1_Y", "B");
     Particle W       = GetParticle(ElectroWeak, "W");
     Particle B       = GetParticle(ElectroWeak, "B");
-    Particle ghost_W = GetParticle(ElectroWeak, "c_A_SU2_L");
+    Particle ghost_W = GetParticle(ElectroWeak, "c_W");
 
     std::cout << ElectroWeak << std::endl;
 
@@ -99,7 +99,7 @@ int main()
                        {{"H0", "H1"},
                         {"W1", "W2", "W3"},
                         {"u_L", "d_L"},
-                        {"\\nu _{eL}", "e_L"},
+                        {"nue ; \\nu_{e_L}", "e_L"},
                         {"c_W1", "c_W2", "c_W3"}});
 
     ///////////////////////////////////////////////////
@@ -132,10 +132,7 @@ int main()
     Particle H0 = GetParticle(ElectroWeak, "H0");
     Particle H1 = GetParticle(ElectroWeak, "H1");
 
-    Particle h   = scalarboson_s("h", ElectroWeak);
-    Particle pi0 = scalarboson_s("\\pi _0", ElectroWeak);
-    Particle pic = scalarboson_s("\\pi _c", ElectroWeak);
-    SetSelfConjugate(pi0, true);
+    Particle h = scalarboson_s("h", ElectroWeak);
     SetSelfConjugate(h, true);
 
     Replaced(ElectroWeak, H0, CSL_0);
@@ -150,11 +147,11 @@ int main()
 
     DiagonalizeMassMatrices(ElectroWeak);
 
-    Rename(ElectroWeak, "B_mix", "A");
-    Rename(ElectroWeak, "W3_mix", "Z");
+    Rename(ElectroWeak, "B", "A");
+    Rename(ElectroWeak, "W3", "Z");
 
     csl::Expr e      = constant_s("e");
-    csl::Expr thetaW = constant_s("\\theta_W");
+    csl::Expr thetaW = constant_s("theta_W");
     csl::Expr g      = GetCoupling(ElectroWeak, "g");
     csl::Expr g_p    = GetCoupling(ElectroWeak, "g'");
     Replaced(ElectroWeak, pow_s(g, 2) + pow_s(g_p, 2), pow_s(g * g_p / e, 2));

--- a/src/marty/models/mssm.cpp
+++ b/src/marty/models/mssm.cpp
@@ -966,7 +966,7 @@ void MSSM_Model::diagonalize2By2Matrices()
 
     mty::Particle rho_u = getParticle("rho_u");
     mty::Particle rho_d = getParticle("rho_d");
-    mty::Particle h     = scalarboson_s("h0; h^0", *this);
+    mty::Particle h     = scalarboson_s("h; h^0", *this);
     mty::Particle H     = scalarboson_s("H0; H^0", *this);
     mty::SetSelfConjugate(h, true);
     mty::SetSelfConjugate(H, true);

--- a/src/marty/models/pmssm_lem/pmssm_content.cpp
+++ b/src/marty/models/pmssm_lem/pmssm_content.cpp
@@ -76,8 +76,8 @@ void PMSSM_LEM::initContent()
         = csl::sqrt_s(csl::pow_s(M_A * M_A - m_Z * m_Z, 2)
                       + csl::pow_s(2 * M_A * m_Z * csl::sin_s(2 * beta), 2));
     abbreviatedMassExpressions.push_back(csl::Abbrev::makeAbbreviation(
-        "m_h0", csl::sqrt_s(CSL_HALF * (mh2_mean - mh2_dev))));
-    m_h0 = csl::constant_s("m_h0");
+        "m_h", csl::sqrt_s(CSL_HALF * (mh2_mean - mh2_dev))));
+    m_h0 = csl::constant_s("m_h");
     abbreviatedMassExpressions.push_back(csl::Abbrev::makeAbbreviation(
         "m_H0", csl::sqrt_s(CSL_HALF * (mh2_mean + mh2_dev))));
     m_H0                    = csl::constant_s("m_H0");
@@ -441,7 +441,7 @@ void PMSSM_LEM::initContent()
     Hp->setMass(m_Hp);
     addParticle(Hp, false);
 
-    h0 = mty::scalarboson_s("h0 ; h^0", *this);
+    h0 = mty::scalarboson_s("h ; h^0", *this);
     h0->setSelfConjugate(true);
     h0->setMass(m_h0);
     addParticle(h0, false);

--- a/tests/system/src/C9_MSSM.cpp
+++ b/tests/system/src/C9_MSSM.cpp
@@ -152,7 +152,7 @@ int main()
           V_cd, V_cb, V_cs,    V_td, V_ts,     V_tb})
         value->setValue(CSL_UNDEF);
 
-    pmssm.getParticle("h0")->setEnabledInDiagrams(false);
+    pmssm.getParticle("h")->setEnabledInDiagrams(false);
     pmssm.getParticle("H0")->setEnabledInDiagrams(false);
     pmssm.getParticle("Hp")->setEnabledInDiagrams(false);
     pmssm.getParticle("W")->setEnabledInDiagrams(false);

--- a/tests/system/src/gm2PMSSM.cpp
+++ b/tests/system/src/gm2PMSSM.cpp
@@ -16,7 +16,7 @@ int main()
     options.setWilsonOperatorCoefficient(-e_em / (4 * m_mu));
     options.addFilters(
         filter::disableParticles(
-            {"W", "Z", "H0", "h0", "A0", "Gp", "G0", "Hp"}),
+            {"W", "Z", "H0", "h", "A0", "Gp", "G0", "Hp"}),
         [&](FeynmanDiagram const &diag) { return !diag.isInLoop("A"); });
 
     Library::setQuadruplePrecision(true);


### PR DESCRIPTION
The Higgs must have a name `h` and not `h0` in the MSSM to avoid the conflict with `H0` on MacOS systems that use case-insensitive files.