### PR TITLE
Fix/amplitude filters

### DIFF
--- a/src/marty/core/feynOptions.cpp
+++ b/src/marty/core/feynOptions.cpp
@@ -148,6 +148,13 @@ void FeynOptions::initDefaultFilters()
         }
         return true;
     });
+    addDiagramFilter([=](FeynmanDiagram const &diagram) {
+        if (excludeExternalLegCorrections
+            && diagram.hasExternalLegCorrections()) {
+            return false;
+        }
+        return true;
+    });
 }
 
 } // namespace mty

--- a/src/marty/core/feynOptions.h
+++ b/src/marty/core/feynOptions.h
@@ -314,7 +314,7 @@ class FeynOptions {
      * @param ...next  Next filters.
      */
     template <class First, class... Next>
-    void addFilters(First &&first, Next &&... next)
+    void addFilters(First &&first, Next &&...next)
     {
         addFilter(std::forward<First>(first));
         addFilters(std::forward<Next>(next)...);
@@ -406,6 +406,9 @@ class FeynOptions {
      * of different diagrams in a process and is then physically irrelevant.
      */
     bool orderInsertions{mty::option::applyInsertionOrdering};
+
+    bool excludeExternalLegCorrections{
+        mty::option::excludeExternalLegsCorrections};
 
     /**
      * @brief Boolean telling if external fermions must be ordered in the

--- a/src/marty/core/feynmanDiagram.h
+++ b/src/marty/core/feynmanDiagram.h
@@ -79,8 +79,8 @@ class FeynmanDiagram {
     FeynmanDiagram(mty::Model const &t_model);
 
     FeynmanDiagram(mty::Model const &t_model,
-                   csl::Expr const & t_expression,
-                   diagram_t const & t_diagram);
+                   csl::Expr const  &t_expression,
+                   diagram_t const  &t_diagram);
 
     /**
      * @brief Tells if the diagram vanishes.
@@ -323,6 +323,20 @@ class FeynmanDiagram {
     }
 
     /**
+     * @brief Tells if at least one external leg is loop-corrected in the
+     * diagram.
+     *
+     * @return true   If an external leg receives a loop correction
+     * @return false  Otherwise
+     *
+     * @sa #externalPropagatorLoop
+     */
+    bool hasExternalLegCorrections() const
+    {
+        return externalPropagatorLoop;
+    }
+
+    /**
      * @brief Tells if a particle is an external particle in the diagram.
      *
      * @details This function can take any type that can be forwarded to
@@ -454,7 +468,7 @@ class FeynmanDiagram {
      */
     static FeynmanDiagram combine(FeynmanDiagram const &A,
                                   FeynmanDiagram const &B,
-                                  Particle const &      mediator);
+                                  Particle const       &mediator);
 
   private:
     /**
@@ -539,6 +553,12 @@ class FeynmanDiagram {
      * is at one-loop.
      */
     int cycleLength;
+
+    /**
+     * @brief Tell if an external leg is loop-corrected in the diagram
+     * (useful to filter-out external leg correction diagrams in amplitudes).
+     */
+    bool externalPropagatorLoop;
 
     /**
      * @brief Number of loops in the diagram.

--- a/src/marty/core/graph.cpp
+++ b/src/marty/core/graph.cpp
@@ -485,7 +485,7 @@ Graph::Graph()
 {
 }
 
-Graph::Graph(const vector<QuantumField> &   field,
+Graph::Graph(const vector<QuantumField>    &field,
              std::map<csl::Tensor, size_t> &vertexIds,
              bool                           t_ruleMode)
     : Graph()
@@ -529,14 +529,14 @@ Graph::Graph(const vector<QuantumField> &   field,
     initConnectedComponent();
 }
 
-Graph::Graph(const csl::Expr &              expr,
+Graph::Graph(const csl::Expr               &expr,
              std::map<csl::Tensor, size_t> &vertexId,
              bool                           t_ruleMode)
     : Graph(convertExprToFields(expr), vertexId, t_ruleMode)
 {
 }
 
-Graph::Graph(Graph const &                             other,
+Graph::Graph(Graph const                              &other,
              std::vector<std::shared_ptr<Node>> const &newNodes)
     : Graph(other)
 {
@@ -687,7 +687,7 @@ bool Graph::isPhysical() const
 
 // Returns the vertex in which one node is
 Vertex const *Graph::getVertexOf(std::shared_ptr<Node> const &node,
-                                 std::vector<Vertex> const &  vertices)
+                                 std::vector<Vertex> const   &vertices)
 {
     auto point = node->field->getPoint().get();
     for (const auto &v : vertices)
@@ -701,7 +701,7 @@ Vertex const *Graph::getVertexOf(std::shared_ptr<Node> const &node,
 // Returns all nodes connected to another node
 std::vector<std::shared_ptr<Node>>
 Graph::nextNodes(std::shared_ptr<Node> const &node,
-                 std::vector<Vertex> const &  vertices)
+                 std::vector<Vertex> const   &vertices)
 {
     auto          partner    = node->partner.lock();
     Vertex const *nextVertex = getVertexOf(partner, vertices);
@@ -715,43 +715,61 @@ Graph::nextNodes(std::shared_ptr<Node> const &node,
     return next;
 }
 
-int Graph::countExternalLegs(std::vector<csl::Tensor>::iterator first,
-                             std::vector<csl::Tensor>::iterator last,
-                             std::vector<Vertex> const &        vertices)
+std::pair<int, bool>
+Graph::countExternalLegs(std::vector<csl::Tensor>::iterator first,
+                         std::vector<csl::Tensor>::iterator last,
+                         std::vector<Vertex> const         &vertices)
 {
-    int nExt = 0;
+    int  nExt     = 0;
+    bool external = false;
     while (first != last) {
         auto pos = std::find_if(
             vertices.begin(), vertices.end(), [&](Vertex const &vertex) {
                 return vertex[0]->field->getPoint().get() == first->get();
             });
+        if (!external) {
+            for (const auto &node : *pos) {
+                if (node->partner.lock()->field->isExternal()) {
+                    external = true;
+                    break;
+                }
+            }
+        }
         nExt += pos->size() - 2;
         ++first;
     }
-    return nExt;
+    return {nExt, external};
 }
 
-int Graph::walk(std::vector<csl::Tensor>::iterator first,
-                std::vector<csl::Tensor>::iterator last,
-                std::shared_ptr<Node> const &      node,
-                std::vector<Vertex> const &        vertices)
+Graph::LoopInformation Graph::walk(std::vector<csl::Tensor>::iterator first,
+                                   std::vector<csl::Tensor>::iterator last,
+                                   std::shared_ptr<Node> const       &node,
+                                   std::vector<Vertex> const         &vertices,
+                                   LoopInformation                    previous)
 {
     *last = node->field->getPoint();
     for (auto iter = first; iter != last; ++iter)
         if (iter->get() == last->get()) {
-            return countExternalLegs(iter, last, vertices);
+            auto [length, external] = countExternalLegs(iter, last, vertices);
+            previous.nLegs          = length;
+            previous.isExternalCorrection = external;
+            previous.loopFields = std::vector<mty::QuantumField const *>(
+                previous.loopFields.begin() + std::distance(first, iter),
+                previous.loopFields.end() - 1);
+            return previous;
         }
     ++last;
+    previous.loopFields.push_back(node->field);
     auto next = nextNodes(node, vertices);
     if (next.empty())
-        return -1;
+        return LoopInformation::invalid();
     for (const auto &nextNode : next) {
-        int res = walk(first, last, nextNode, vertices);
-        if (res != -1) {
+        LoopInformation res = walk(first, last, nextNode, vertices, previous);
+        if (res.nLegs != -1) {
             return res;
         }
     }
-    return -1;
+    return LoopInformation::invalid();
 }
 
 bool Graph::isValid() const
@@ -762,10 +780,11 @@ bool Graph::isValid() const
         && !mty::option::excludeTriangles && !mty::option::excludeBoxes
         && !mty::option::excludePentagons)
         return true;
-    auto const &             vertices = connectedCompo.getVertices();
+    auto const              &vertices = connectedCompo.getVertices();
     std::vector<csl::Tensor> points(vertices.size());
     auto                     first = vertices[0][0];
-    auto cycleLength = walk(points.begin(), points.begin(), first, vertices);
+    auto [cycleLength, _, __]
+        = walk(points.begin(), points.begin(), first, vertices);
     if (cycleLength == 1 && mty::option::excludeMassCorrections)
         return false;
     if (cycleLength == 2 && mty::option::excludeMassCorrections)
@@ -795,10 +814,10 @@ int Graph::getFieldDimension() const
 }
 
 Graph::Expr_type
-Graph::getPartialExpression(vector<shared_ptr<Node>> &  nodes,
+Graph::getPartialExpression(vector<shared_ptr<Node>>   &nodes,
                             const vector<QuantumField> &initialOrder,
-                            mty::FeynruleMomentum &     witnessMapping,
-                            csl::Expr const &           globalFactor) const
+                            mty::FeynruleMomentum      &witnessMapping,
+                            csl::Expr const            &globalFactor) const
 {
     HEPAssert(nodes.size() % 2 == 0,
               mty::error::RuntimeError,
@@ -1019,7 +1038,7 @@ Graph::copyNodes(const vector<shared_ptr<Node>> &toCopy)
 }
 
 void Graph::applySymmetry(
-    vector<shared_ptr<Node>> &                     nodes,
+    vector<shared_ptr<Node>>                      &nodes,
     const ObjectPermutation<const QuantumField *> &permutation)
 {
     for (auto &node : nodes)
@@ -1044,8 +1063,8 @@ vector<int> Graph::getContractibleIntVertices(const QuantumField *field) const
     for (size_t i = 0; i != independentVertices.size(); ++i) {
         const int begin = independentVertices[i];
         const int end   = (i != independentVertices.size() - 1)
-                            ? independentVertices[i + 1]
-                            : intVertex.size();
+                              ? independentVertices[i + 1]
+                              : intVertex.size();
         for (int index = begin; index != end; ++index) {
             if (intVertex[index].getDegeneracy(field) > 0) {
                 vertices.push_back(index);
@@ -1173,8 +1192,8 @@ std::vector<std::shared_ptr<Graph>> Graph::contractionStep() const
     return nonZeroDiagrams;
 }
 
-bool Graph::compareFieldsDummyPoint(const QuantumField *           fieldA,
-                                    const QuantumField *           fieldB,
+bool Graph::compareFieldsDummyPoint(const QuantumField            *fieldA,
+                                    const QuantumField            *fieldB,
                                     map<csl::Tensor, csl::Tensor> &constraints,
                                     bool                           fieldBlind)
 {
@@ -1215,8 +1234,8 @@ bool Graph::compareFieldsDummyPoint(const QuantumField *           fieldA,
 }
 
 bool Graph::compareNodesWithConstraints(
-    const Node *                   nodeA,
-    const Node *                   nodeB,
+    const Node                    *nodeA,
+    const Node                    *nodeB,
     map<csl::Tensor, csl::Tensor> &constraints,
     bool                           fieldBlind)
 {
@@ -1287,7 +1306,7 @@ bool Graph::compareNodesWithConstraints(
 }
 
 void Graph::addFoundNode(const shared_ptr<Node> &newNode,
-                         vector<csl::Tensor> &   foundNodes)
+                         vector<csl::Tensor>    &foundNodes)
 {
     const QuantumField *f1     = newNode->field;
     const QuantumField *f2     = newNode->partner.lock()->field;
@@ -1322,7 +1341,7 @@ void Graph::sortNodes(vector<shared_ptr<Node>> &nodes)
     }
 }
 
-bool Graph::compare(const Graph &                       other,
+bool Graph::compare(const Graph                        &other,
                     std::map<csl::Tensor, csl::Tensor> &constraints,
                     bool                                fieldBlind) const
 {
@@ -1480,7 +1499,7 @@ void WickCalculator::eliminateNonPhysicalDiagrams(
         }
 }
 
-void WickCalculator::calculateDiagrams(Model const *      model,
+void WickCalculator::calculateDiagrams(Model const       *model,
                                        FeynOptions const &options)
 {
     int dim = initialDiagram.getFieldDimension();
@@ -1538,14 +1557,14 @@ void WickCalculator::calculateDiagrams(Model const *      model,
 }
 
 csl::Expr WickCalculator::applyWickTheoremOnDiagram(
-    const Graph &                       diagram,
+    const Graph                        &diagram,
     std::vector<mty::FeynruleMomentum> &witnessMapping,
     bool                                ruleMode)
 {
     if (ruleMode) {
-        auto res = (witnessMapping.empty())
-                       ? diagram.getExpression()
-                       : diagram.getExpression(witnessMapping[0]);
+        auto                   res = (witnessMapping.empty())
+                                         ? diagram.getExpression()
+                                         : diagram.getExpression(witnessMapping[0]);
         std::vector<csl::Expr> terms;
         terms.reserve(res.size());
         for (const auto &el : res)
@@ -1560,16 +1579,16 @@ csl::Expr WickCalculator::applyWickTheoremOnDiagram(
 
 csl::vector_expr WickCalculator::applyWickTheoremOnDiagrams(
     const std::vector<std::shared_ptr<Graph>> &diagrams,
-    std::vector<mty::FeynruleMomentum> &       witnessMapping,
+    std::vector<mty::FeynruleMomentum>        &witnessMapping,
     bool                                       ruleMode)
 {
     return convertGraphsToCorrelators(diagrams, witnessMapping, ruleMode);
 }
 
 std::vector<mty::FeynmanDiagram>
-WickCalculator::getDiagrams(mty::Model const *             model,
-                            FeynOptions const &            options,
-                            const csl::Expr &              initial,
+WickCalculator::getDiagrams(mty::Model const              *model,
+                            FeynOptions const             &options,
+                            const csl::Expr               &initial,
                             std::map<csl::Tensor, size_t> &vertexIds,
                             bool symmetrizeExternalLegs,
                             bool ruleMode)
@@ -1585,10 +1604,10 @@ WickCalculator::getDiagrams(mty::Model const *             model,
 }
 
 std::vector<mty::FeynmanDiagram>
-WickCalculator::getDiagrams(mty::Model const *                  model,
-                            FeynOptions const &                 options,
-                            const csl::Expr &                   initial,
-                            std::map<csl::Tensor, size_t> &     vertexIds,
+WickCalculator::getDiagrams(mty::Model const                   *model,
+                            FeynOptions const                  &options,
+                            const csl::Expr                    &initial,
+                            std::map<csl::Tensor, size_t>      &vertexIds,
                             std::vector<mty::FeynruleMomentum> &witnessMapping,
                             bool symmetrizeExternalLegs,
                             bool ruleMode)
@@ -1799,7 +1818,7 @@ bool operator==(const shared_ptr<Node> &A, const shared_ptr<Node> &B)
 
 bool comparePriority(const shared_ptr<Node> &A,
                      const shared_ptr<Node> &B,
-                     const vector<Tensor> &  foundNodes)
+                     const vector<Tensor>   &foundNodes)
 {
     if (not internal_comparePriority(A, A->partner.lock(), foundNodes))
         return false;
@@ -1810,7 +1829,7 @@ bool comparePriority(const shared_ptr<Node> &A,
 
 bool internal_comparePriority(const shared_ptr<Node> &A,
                               const shared_ptr<Node> &B,
-                              const vector<Tensor> &  foundNodes)
+                              const vector<Tensor>   &foundNodes)
 {
     bool extA = A->field->isExternal();
     bool extB = B->field->isExternal();
@@ -1904,7 +1923,7 @@ int getCommutationSign(const std::vector<const mty::QuantumField *> &A,
     return getCommutationSign(A_static, B);
 }
 
-int getCommutationSign(const std::vector<QuantumField> & A,
+int getCommutationSign(const std::vector<QuantumField>  &A,
                        std::vector<const QuantumField *> B)
 {
     int sign = 1;

--- a/src/marty/core/graph.cpp
+++ b/src/marty/core/graph.cpp
@@ -754,12 +754,13 @@ Graph::LoopInformation Graph::walk(std::vector<csl::Tensor>::iterator first,
             previous.nLegs          = length;
             previous.isExternalCorrection = external;
             previous.loopFields = std::vector<mty::QuantumField const *>(
-                previous.loopFields.begin() + std::distance(first, iter),
-                previous.loopFields.end() - 1);
+                previous.loopFields.begin() + 2 * std::distance(first, iter),
+                previous.loopFields.end());
             return previous;
         }
     ++last;
     previous.loopFields.push_back(node->field);
+    previous.loopFields.push_back(node->partner.lock()->field);
     auto next = nextNodes(node, vertices);
     if (next.empty())
         return LoopInformation::invalid();

--- a/src/marty/core/mrtOptions.h
+++ b/src/marty/core/mrtOptions.h
@@ -38,29 +38,30 @@ inline bool amputateExternalLegs = false;
 // Options on amplitude computation
 ///////////////////////////////////////////////////
 
-inline bool simplifyAmplitudes        = true;
-inline bool orderExternalFermions     = false;
-inline bool discardLowerOrders        = true;
-inline bool evaluateFermionTraces     = true;
-inline bool excludeTadpoles           = true;
-inline bool excludeMassCorrections    = false;
-inline bool excludeTriangles          = false;
-inline bool excludeBoxes              = false;
-inline bool excludePentagons          = false;
-inline bool computeFirstIntegral      = true;
-inline bool dimensionalRegularization = true;
-inline bool searchAbreviations        = true;
-inline bool expandAbbreviations       = false;
-inline bool applyFermionChain         = false;
-inline bool abbreviateColorStructures = true;
-inline bool decomposeInOperators      = false;
-inline bool decomposeInLocalOperator  = true;
-inline bool applyEquationsOfMotion    = true;
-inline bool addLocalTerms             = true;
-inline bool verboseAmplitude          = true;
-inline bool testRepresentations       = true;
-inline bool keepOnlyFirstMassInLoop   = false;
-inline bool useMassiveSimplifications = true;
+inline bool simplifyAmplitudes             = true;
+inline bool orderExternalFermions          = false;
+inline bool discardLowerOrders             = true;
+inline bool evaluateFermionTraces          = true;
+inline bool excludeExternalLegsCorrections = false;
+inline bool excludeTadpoles                = true;
+inline bool excludeMassCorrections         = false;
+inline bool excludeTriangles               = false;
+inline bool excludeBoxes                   = false;
+inline bool excludePentagons               = false;
+inline bool computeFirstIntegral           = true;
+inline bool dimensionalRegularization      = true;
+inline bool searchAbreviations             = true;
+inline bool expandAbbreviations            = false;
+inline bool applyFermionChain              = false;
+inline bool abbreviateColorStructures      = true;
+inline bool decomposeInOperators           = false;
+inline bool decomposeInLocalOperator       = true;
+inline bool applyEquationsOfMotion         = true;
+inline bool addLocalTerms                  = true;
+inline bool verboseAmplitude               = true;
+inline bool testRepresentations            = true;
+inline bool keepOnlyFirstMassInLoop        = false;
+inline bool useMassiveSimplifications      = true;
 
 // This one is a reference ! Only to have this option available in mty::option
 inline bool &keepEvanescentOperators = sgl::option::keepEvanescentOperators;


### PR DESCRIPTION
The amplitude selection for particles in a loop has been corrected. 

the `excludeExternalLegCorrections` has been added to allow users to very simply disable diagrams that feature a loop on an external leg.