### PR TITLE
Latex output

### DIFF
--- a/examples/sampleQCD.cpp
+++ b/examples/sampleQCD.cpp
@@ -59,6 +59,10 @@ int main()
     Display(_66bar);
     Show(_66bar);
 
+    for (const auto &expr : _66bar.obtainExpressions()) {
+        std::cout << csl::ToLatex(expr) << std::endl;
+    }
+
     csl::Expr crossSection = QCD.computeSquaredAmplitude(_66bar);
 
     std::cout << "Squared amplitude = " << crossSection << std::endl;
@@ -70,6 +74,8 @@ int main()
     crossSection
         = crossSection / (64 * CSL_PI * CSL_PI * s)
           * sqrt_s((1 - 4 * pow_s(m_u, 2) / s) / (1 - 4 * pow_s(m_X, 2) / s));
+
+    std::cout << csl::ToLatex(crossSection) << std::endl;
 
     std::cout << "Cross Section = " << crossSection << std::endl;
 

--- a/src/csl/abstract.cpp
+++ b/src/csl/abstract.cpp
@@ -158,11 +158,10 @@ void Abstract::printExplicit(int mode) const
     print(mode);
 }
 
-string Abstract::printLaTeX(int) const
+void Abstract::printLaTeX(int, std::ostream &) const
 {
     print();
     CALL_SMERROR(CSLError::AbstractCallError);
-    return "";
 }
 
 LibDependency Abstract::getLibDependency() const

--- a/src/csl/abstract.h
+++ b/src/csl/abstract.h
@@ -129,7 +129,10 @@ class Abstract {
      * another expr.
      * \return The string corresponding to the LaTeX output.
      */
-    virtual std::string printLaTeX(int mode = 0) const;
+    virtual void printLaTeX(
+        int mode = 0,
+        std::ostream &out = std::cout
+    ) const;
 
     virtual std::vector<Parent> getSubSymbols() const = 0;
 

--- a/src/csl/booleanOperators.cpp
+++ b/src/csl/booleanOperators.cpp
@@ -192,11 +192,47 @@ void BooleanOperator::printCode(int mode, std::ostream &out) const
         out << '\n';
 }
 
-std::string BooleanOperator::printLaTeX(int mode) const
+void BooleanOperator::printLaTeX(int mode, std::ostream &out) const
 {
-    std::ostringstream sout;
-    print(mode, sout);
-    return sout.str();
+    const size_t first = size() - 2;
+    out << "\\left\\lbrace";
+    out << "\\begin{array}{l}";
+    argument[first]->printLaTeX(1, out);
+    out << "\\quad \\mathrm{if}\\";
+    switch (type) {
+    case True:
+        out << "\\left[" << argument[0] << "\\right]";
+        break;
+    case False:
+        out << "\\mathrm{not}\\ \\left[" << argument[0] << "\\right]";
+        break;
+    case EqualTo:
+        out << "\\left[" << argument[0] << "\\right]\\, ==\\, \\left[" << argument[1] << "\\right]";
+        break;
+    case DifferentThan:
+        out << "\\left[" << argument[0] << "\\right]\\, != \\,\\left[" << argument[1] << "\\right]";
+        break;
+    case LessThan:
+        out << "\\left[" << argument[0] << "\\right]\\, < \\,\\left[" << argument[1] << "\\right]";
+        break;
+    case LessThanOrEqualTo:
+        out << "\\left[" << argument[0] << "\\right]\\, <= \\,\\left[" << argument[1] << "\\right]";
+        break;
+    case GreaterThan:
+        out << "\\left[" << argument[0] << "\\right]\\, > \\,\\left[" << argument[1] << "\\right]";
+        break;
+    case GreaterThanOrEqualTo:
+        out << "\\left[" << argument[0] << "\\right]\\, >= \\,\\left[" << argument[1] << "\\right]";
+        break;
+    default:
+        CALL_SMERROR(CSLError::TypeError);
+    }
+    out << "\\\\";
+    argument[first+1]->printLaTeX(1, out);
+    out << "\\end{array}";
+    if (mode == 0) {
+        out << "\n";
+    }
 }
 
 LibDependency BooleanOperator::getLibDependency() const

--- a/src/csl/booleanOperators.h
+++ b/src/csl/booleanOperators.h
@@ -79,7 +79,7 @@ class BooleanOperator : public AbstractMultiFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 

--- a/src/csl/buildingBlock.cpp
+++ b/src/csl/buildingBlock.cpp
@@ -159,7 +159,7 @@ std::optional<Expr> Complexified::getComplexArgument() const
 void Complexified::printProp(std::ostream &fout) const
 {
     if (isComplexConjugate())
-        fout << "^(*)";
+        fout << "^{*}";
 }
 
 csl::ComplexProperty Complexified::getComplexProperty() const

--- a/src/csl/commutation.cpp
+++ b/src/csl/commutation.cpp
@@ -142,24 +142,22 @@ void Commutator::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Commutator::printLaTeX(int mode) const
+void Commutator::printLaTeX(int mode, std::ostream &out) const
 {
     stringstream sout;
     if (sign == -1)
-        sout << "[ ";
+        sout << "\\left[ ";
     else
-        sout << "{ ";
-    sout << argument[0]->printLaTeX(1);
-    sout << " , ";
-    sout << argument[1]->printLaTeX(1);
+        sout << "\\left\\lbrace ";
+    argument[0]->printLaTeX(1, out);
+    out << ",\\ ";
+    argument[1]->printLaTeX(1, out);
     if (sign == -1)
-        sout << " ]";
+        sout << " \\right]";
     else
-        sout << " }";
+        sout << " \\right\\rbrace";
     if (mode == 0)
         sout << endl;
-
-    return sout.str();
 }
 
 long double Commutator::evaluateScalar() const

--- a/src/csl/commutation.h
+++ b/src/csl/commutation.h
@@ -111,7 +111,7 @@ class Commutator : public AbstractDuoFunc {
                std::ostream &out     = std::cout,
                LibraryMode   libMode = LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     long double evaluateScalar() const override;
 

--- a/src/csl/comparison.cpp
+++ b/src/csl/comparison.cpp
@@ -69,9 +69,9 @@ void Arbitrary::print(int mode, std::ostream &out, LibraryMode) const
         out << endl;
 }
 
-string Arbitrary::printLaTeX(int) const
+void Arbitrary::printLaTeX(int, std::ostream &out) const
 {
-    return name;
+    out << name;
 }
 
 optional<Expr> Arbitrary::evaluate(csl::eval::mode) const

--- a/src/csl/comparison.h
+++ b/src/csl/comparison.h
@@ -71,7 +71,7 @@ class Arbitrary : public AbstractLiteral {
                std::ostream &out     = std::cout,
                LibraryMode   libMode = LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     std::optional<Expr> evaluate(csl::eval::mode user_mode
                                  = csl::eval::base) const override;

--- a/src/csl/cslcomplex.cpp
+++ b/src/csl/cslcomplex.cpp
@@ -94,16 +94,13 @@ void RealPart::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string RealPart::printLaTeX(int mode) const
+void RealPart::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << "Re(";
-    sout << argument->printLaTeX(1);
-    sout << ")";
+    out << "\\Re\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency RealPart::getLibDependency() const
@@ -268,16 +265,13 @@ void ImaginaryPart::print(int           mode,
         out << endl;
 }
 
-string ImaginaryPart::printLaTeX(int mode) const
+void ImaginaryPart::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << "Im(";
-    sout << argument->printLaTeX(1);
-    sout << ")";
+    out << "\\Im\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency ImaginaryPart::getLibDependency() const

--- a/src/csl/cslcomplex.h
+++ b/src/csl/cslcomplex.h
@@ -54,7 +54,7 @@ class RealPart : public Operator<AbstractFunc> {
                std::ostream &out     = std::cout,
                LibraryMode   libMode = LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -104,7 +104,7 @@ class ImaginaryPart : public Operator<AbstractFunc> {
                std::ostream &out     = std::cout,
                LibraryMode   libMode = LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 

--- a/src/csl/index.cpp
+++ b/src/csl/index.cpp
@@ -175,14 +175,12 @@ void Index::print() const
     cout << getName();
 }
 
-string Index::printLaTeX() const
+void Index::printLaTeX(std::ostream &out) const
 {
     if (type == cslIndex::Fixed) {
-        ostringstream sout;
-        sout << static_cast<int>(nameOrValue);
-        return sout.str();
+        out << static_cast<int>(nameOrValue);
     }
-    return std::string(getName());
+    out << getName();
 }
 
 void Index::printDefinition(std::ostream &out, int indentSize) const

--- a/src/csl/index.h
+++ b/src/csl/index.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <iostream>
 
 namespace csl {
 class Space;
@@ -247,7 +248,7 @@ class Index {
      * \brief Returns the LaTeX name of the Index (for now there is no
      * difference with the regular name).
      */
-    std::string printLaTeX() const;
+    void printLaTeX(std::ostream &out = std::cout) const;
 
     void printDefinition(std::ostream &out, int indentSize) const;
 

--- a/src/csl/indicial.cpp
+++ b/src/csl/indicial.cpp
@@ -2823,20 +2823,31 @@ void TensorElement::printCode(int, std::ostream &out) const
         out << ")";
 }
 
-string TensorElement::printLaTeX(int mode) const
+void TensorElement::printLaTeX(int mode, std::ostream &out) const
 {
     const int     nIndices = index.size();
-    ostringstream sout;
-    sout << getLatexName();
+    out << "{" << getLatexName() << "}";
+    printProp(out);
     if (nIndices > 0) {
-        sout << "_";
-        sout << index;
+        out << "_{";
+        // covariant indices
+        for (const auto &i : index) {
+            if (!i.getSign()) {
+                i.printLaTeX(out);
+            }
+        }
+        out << "}";
+        out << "^{";
+        // contravariant indices
+        for (const auto &i : index) {
+            if (i.getSign()) {
+                i.printLaTeX(out);
+            }
+        }
+        out << "}";
     }
-    printProp(sout);
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 std::vector<Parent> TensorElement::getSubSymbols() const

--- a/src/csl/indicial.h
+++ b/src/csl/indicial.h
@@ -893,7 +893,7 @@ class TensorElement : public AbstractElement {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     std::vector<Parent> getSubSymbols() const override;
 

--- a/src/csl/interface.cpp
+++ b/src/csl/interface.cpp
@@ -23,12 +23,20 @@
 #include "space.h"
 #include "tensorField.h"
 #include "utils.h"
+#include <sstream>
 
 #define OPT(expr, func) ((expr->func).value_or(expr))
 
 using namespace std;
 
 namespace csl {
+
+std::string ToLatex(csl::Expr const &expr)
+{
+    std::ostringstream sout;
+    expr->printLaTeX(1, sout);
+    return sout.str();
+}
 
 Expr GetSymbol(std::string_view name, Expr const &init)
 {

--- a/src/csl/interface.h
+++ b/src/csl/interface.h
@@ -32,6 +32,9 @@ namespace csl {
 class TensorField;
 class TDerivative;
 
+[[nodiscard]]
+std::string ToLatex(Expr const &expr);
+
 template <class T>
 [[nodiscard]] inline csl::Type GetType(T const &expr)
 {

--- a/src/csl/literal.cpp
+++ b/src/csl/literal.cpp
@@ -178,17 +178,13 @@ void Constant::printCode(int, std::ostream &out) const
             << ")";
 }
 
-string Constant::printLaTeX(int mode) const
+void Constant::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
+    out << "{" << parent->getLatexName() << "}";
     if (mode == 0 and parent->isValued())
-        sout << parent->getLatexName() << " = " << parent->getValue() << endl;
+        out << " = " << parent->getValue() << endl;
     else if (mode == 0)
-        sout << parent->getLatexName() << endl;
-    else
-        sout << parent->getLatexName();
-
-    return sout.str();
+        out << endl;
 }
 
 std::vector<Parent> Constant::getSubSymbols() const
@@ -406,17 +402,13 @@ void Variable::printCode(int, std::ostream &out) const
             << ")";
 }
 
-string Variable::printLaTeX(int mode) const
+void Variable::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
+    out << "{" << parent->getLatexName() << "}";
     if (mode == 0 and getValued())
-        sout << getLatexName() << " = " << getValue() << endl;
+        out << " = " << getValue() << endl;
     else if (mode == 0)
-        sout << getLatexName() << endl;
-    else
-        sout << getLatexName();
-
-    return sout.str();
+        out << endl;
 }
 
 std::vector<Parent> Variable::getSubSymbols() const
@@ -567,9 +559,12 @@ void Imaginary::printCode(int, std::ostream &out) const
     out << "CSL_I";
 }
 
-string Imaginary::printLaTeX(int) const
+void Imaginary::printLaTeX(int mode, std::ostream &out) const
 {
-    return "i";
+    out << "i";
+    if (mode == 0) {
+        out << '\n';
+    }
 }
 
 long double Imaginary::evaluateScalar() const
@@ -635,15 +630,12 @@ void IntFactorial::printCode(int, std::ostream &out) const
     out << "csl::intfactorial_s(" << value << ")";
 }
 
-string IntFactorial::printLaTeX(int mode) const
+void IntFactorial::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
     if (mode == 0)
-        sout << value << "!" << endl;
+        out << value << "!" << endl;
     else
-        sout << value << "!";
-
-    return sout.str();
+        out << value << "!";
 }
 
 long double IntFactorial::evaluateScalar() const

--- a/src/csl/literal.h
+++ b/src/csl/literal.h
@@ -126,7 +126,7 @@ class Constant : public AbstractLiteral {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     std::vector<Parent> getSubSymbols() const override;
 
@@ -252,7 +252,7 @@ class Variable : public AbstractLiteral {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     std::vector<Parent> getSubSymbols() const override;
 
@@ -355,7 +355,7 @@ class IntFactorial : public AbstractLiteral {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief Returns the **evaluation of the factorial**.
      * \return **value!**
@@ -445,7 +445,7 @@ class Imaginary : public AbstractLiteral {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief \b Tries to evaluate the Imaginary **as a real**.
      * \details This function returns \b 0 and prints a \b warning message

--- a/src/csl/mathFunctions.cpp
+++ b/src/csl/mathFunctions.cpp
@@ -115,17 +115,13 @@ void Abs::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Abs::printLaTeX(int mode) const
+void Abs::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\text{bas}\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\mathrm{abs}\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Abs::getLibDependency() const
@@ -226,17 +222,13 @@ void Exp::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Exp::printLaTeX(int mode) const
+void Exp::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "e^{";
-    sout << argument->printLaTeX(1);
-    sout << "}";
+    out << "e^{";
+    argument->printLaTeX(1, out);
+    out << "}";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Exp::getLibDependency() const
@@ -379,17 +371,13 @@ void Log::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Log::printLaTeX(int mode) const
+void Log::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\log\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\log\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Log::getLibDependency() const
@@ -487,17 +475,13 @@ void Cos::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Cos::printLaTeX(int mode) const
+void Cos::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\cos\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\cos\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Cos::getLibDependency() const
@@ -618,17 +602,13 @@ void Sin::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Sin::printLaTeX(int mode) const
+void Sin::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\sin\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\sin\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Sin::getLibDependency() const
@@ -765,17 +745,13 @@ void Tan::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Tan::printLaTeX(int mode) const
+void Tan::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\tan\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\tan\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Tan::getLibDependency() const
@@ -894,17 +870,13 @@ void ACos::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string ACos::printLaTeX(int mode) const
+void ACos::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\acos\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\acos\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency ACos::getLibDependency() const
@@ -999,17 +971,13 @@ void ASin::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string ASin::printLaTeX(int mode) const
+void ASin::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\asin\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\asin\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency ASin::getLibDependency() const
@@ -1077,17 +1045,13 @@ void ATan::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string ATan::printLaTeX(int mode) const
+void ATan::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\atan\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\atan\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency ATan::getLibDependency() const
@@ -1181,17 +1145,13 @@ void Cosh::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Cosh::printLaTeX(int mode) const
+void Cosh::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\cosh\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\cosh\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Cosh::getLibDependency() const
@@ -1284,17 +1244,13 @@ void Sinh::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Sinh::printLaTeX(int mode) const
+void Sinh::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\sinh\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\sinh\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Sinh::getLibDependency() const
@@ -1405,17 +1361,13 @@ void Tanh::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Tanh::printLaTeX(int mode) const
+void Tanh::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\tanh\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\tanh\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Tanh::getLibDependency() const
@@ -1482,17 +1434,13 @@ void ACosh::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string ACosh::printLaTeX(int mode) const
+void ACosh::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\acosh\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\acosh\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency ACosh::getLibDependency() const
@@ -1558,17 +1506,13 @@ void ASinh::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string ASinh::printLaTeX(int mode) const
+void ASinh::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\asinh\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\asinh\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency ASinh::getLibDependency() const
@@ -1637,17 +1581,13 @@ void ATanh::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string ATanh::printLaTeX(int mode) const
+void ATanh::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-
-    sout << "\\atanh\\left(";
-    sout << argument->printLaTeX(1);
-    sout << "\\right)";
+    out << "\\atanh\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency ATanh::getLibDependency() const
@@ -1731,13 +1671,16 @@ void Angle::printCode(int, std::ostream &out) const
     out << ")";
 }
 
-string Angle::printLaTeX(int) const
+void Angle::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << "\\text{angle}\\left(" << argument[0]->printLaTeX(1);
-    sout << ", " << argument[1]->printLaTeX(1) << "\\right) ";
-
-    return sout.str();
+    out << "\\text{angle}\\left(";
+    argument[0]->printLaTeX(1, out);
+    out << ",\\ ";
+    argument[1]->printLaTeX(1, out);
+    out << "\\right) ";
+    if (mode == 0) {
+        out << endl;
+    }
 }
 
 LibDependency Angle::getLibDependency() const
@@ -1850,15 +1793,12 @@ void Factorial::print(int mode, std::ostream &out, LibraryMode libMode) const
         out << endl;
 }
 
-string Factorial::printLaTeX(int mode) const
+void Factorial::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << argument->printLaTeX(1);
-    sout << "!";
+    argument->printLaTeX(5, out); // max precedence
+    out << "!";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 LibDependency Factorial::getLibDependency() const
@@ -1979,16 +1919,13 @@ void DiracDelta::print(int mode, std::ostream &out, LibraryMode) const
         out << endl;
 }
 
-string DiracDelta::printLaTeX(int mode) const
+void DiracDelta::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << "\\delta{";
-    argument->print(1);
-    sout << "}";
+    out << "\\delta\\left(";
+    argument->printLaTeX(1, out);
+    out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 optional<Expr> DiracDelta::derive(Expr_info expr) const

--- a/src/csl/mathFunctions.h
+++ b/src/csl/mathFunctions.h
@@ -60,7 +60,7 @@ class Abs : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -147,7 +147,7 @@ class Exp : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -237,7 +237,7 @@ class Log : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -320,7 +320,7 @@ class Cos : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -403,7 +403,7 @@ class Sin : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -486,7 +486,7 @@ class Tan : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -569,7 +569,7 @@ class ACos : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -652,7 +652,7 @@ class ASin : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -727,7 +727,7 @@ class ATan : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -805,7 +805,7 @@ class Angle : public AbstractDuoFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -887,7 +887,7 @@ class Cosh : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -970,7 +970,7 @@ class Sinh : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -1053,7 +1053,7 @@ class Tanh : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -1128,7 +1128,7 @@ class ACosh : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -1203,7 +1203,7 @@ class ASinh : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -1278,7 +1278,7 @@ class ATanh : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -1353,7 +1353,7 @@ class Factorial : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -1439,7 +1439,7 @@ class DiracDelta : public AbstractFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief \b Derives the atanh function.
      * \return derivative(argument)*(1-atanh^2(argument))

--- a/src/csl/numerical.cpp
+++ b/src/csl/numerical.cpp
@@ -107,17 +107,14 @@ void Float::print(int mode, std::ostream &out, LibraryMode) const
     printProp(out);
 }
 
-string Float::printLaTeX(int mode) const
+void Float::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
     if (mode == 0)
-        sout << value << endl;
+        out << value << endl;
     else if (value < 0)
-        sout << "(" << value << ")";
+        out << "(" << value << ")";
     else
-        sout << value;
-
-    return sout.str();
+        out << value;
 }
 
 long double Float::evaluateScalar() const
@@ -301,17 +298,14 @@ void Integer::print(int mode, std::ostream &out, LibraryMode) const
     printProp(out);
 }
 
-string Integer::printLaTeX(int mode) const
+void Integer::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
     if (mode == 0)
-        sout << value << endl;
+        out << value << endl;
     else if (value < 0)
-        sout << "(" << value << ")";
+        out << "(" << value << ")";
     else
-        sout << value;
-
-    return sout.str();
+        out << value;
 }
 
 long double Integer::evaluateScalar() const
@@ -518,18 +512,15 @@ void IntFraction::printCode(int, std::ostream &out) const
     out << "csl::intfraction_s(" << num << ", " << denom << ")";
 }
 
-string IntFraction::printLaTeX(int mode) const
+void IntFraction::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
     if (mode == 0)
-        sout << "\\frac{" << num << "}{" << denom << "}";
+        out << "\\frac{" << num << "}{" << denom << "}";
     else if (mode > 3)
-        sout << "\\left("
-             << "\\frac{" << num << "}{" << denom << "}\\right)";
+        out << "\\left("
+            << "\\frac{" << num << "}{" << denom << "}\\right)";
     else
-        sout << "\\frac{" << num << "}{" << denom << "}";
-
-    return sout.str();
+        out << "\\frac{" << num << "}{" << denom << "}";
 }
 
 long double IntFraction::evaluateScalar() const
@@ -788,21 +779,19 @@ void Complex::printCode(int, std::ostream &out) const
     out << "csl::complex_s(" << real << ", " << imag << ")";
 }
 
-std::string Complex::printLaTeX(int mode) const
+void Complex::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
     if (mode > 1 and imag != CSL_0)
-        sout << "(";
-    sout << real->printLaTeX(1);
+        out << "(";
+    real->printLaTeX(1, out);
     if (imag != CSL_0) {
-        sout << " +i";
-        sout << imag->printLaTeX(1);
+        out << " +i";
+        imag->printLaTeX(1, out);
     }
     if (mode > 1 and imag != CSL_0)
-        sout << ")";
+        out << ")";
     if (mode == 0)
-        sout << endl;
-    return sout.str();
+        out << endl;
 }
 
 long double Complex::evaluateScalar() const

--- a/src/csl/numerical.h
+++ b/src/csl/numerical.h
@@ -120,7 +120,7 @@ class Integer : public AbstractNumerical {
                std::ostream &out     = std::cout,
                LibraryMode   libMode = LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     long double evaluateScalar() const override;
 
@@ -205,7 +205,7 @@ class Float : public AbstractNumerical {
                std::ostream &out     = std::cout,
                LibraryMode   libMode = LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     long double evaluateScalar() const override;
 
@@ -306,7 +306,7 @@ class IntFraction : public AbstractNumerical {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief Evaluates the IntFraction.
      * \return double(\b num/\b denom)
@@ -422,7 +422,7 @@ class Complex : public AbstractNumerical {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     long double evaluateScalar() const override;
 

--- a/src/csl/operations.h
+++ b/src/csl/operations.h
@@ -107,7 +107,7 @@ class Sum : public AbstractMultiFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief Return the \b sum of all the arguments.
      * \return The sum of the scalar evaluation of all the arguments.
@@ -236,7 +236,7 @@ class Polynomial : public AbstractMultiFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief Return the \b polynomial of all the arguments.
      * \return The polynomial of the scalar evaluation of all the arguments.
@@ -406,7 +406,7 @@ class Prod : public AbstractMultiFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief Return the \b product of all the arguments.
      * \return The product of the scalar evaluation of all the arguments.
@@ -560,7 +560,7 @@ class Pow : public AbstractDuoFunc {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     LibDependency getLibDependency() const override;
 
@@ -695,7 +695,7 @@ class Derivative : public Operator<AbstractDuoFunc> {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     /*! \brief Return the \b derivative of the first argument wrt the second.
      * \return The derivative of the scalar evaluation of the two arguments.
@@ -787,7 +787,7 @@ class Integral : public Operator<AbstractDuoFunc> {
                std::ostream &out     = std::cout,
                LibraryMode   libMode = LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     // long double evaluateScalar() const override;
 

--- a/src/csl/pseudoIntegral.cpp
+++ b/src/csl/pseudoIntegral.cpp
@@ -585,27 +585,24 @@ void ScalarIntegral::printCode(int, std::ostream &out) const
     out << ")";
 }
 
-string ScalarIntegral::printLaTeX(int mode) const
+void ScalarIntegral::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << "int";
+    out << "int";
     if (inf != -CSL_INF or sup != CSL_INF) {
-        sout << "_{";
-        sout << inf->printLaTeX(1);
-        sout << "}^{";
-        sout << sup->printLaTeX(1);
-        sout << "}";
+        out << "_{";
+        inf->printLaTeX(1, out);
+        out << "}^{";
+        sup->printLaTeX(1, out);
+        out << "}";
     }
-    sout << "\\left(";
-    sout << "d" << variable->getName() << "\\cdot";
+    out << "\\left(";
+    out << "d" << variable->getName() << "\\cdot";
     if (argument != CSL_1)
-        sout << argument->printLaTeX(1);
+        argument->printLaTeX(1, out);
     if (not empty)
-        sout << "\\right)";
+        out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 unique_Expr ScalarIntegral::copy_unique() const
@@ -761,27 +758,24 @@ void VectorIntegral::printCode(int, std::ostream &out) const
     out << ")";
 }
 
-string VectorIntegral::printLaTeX(int mode) const
+void VectorIntegral::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << "int";
+    out << "int";
     if (inf != -CSL_INF or sup != CSL_INF) {
-        sout << "_{";
-        sout << inf->printLaTeX(1);
-        sout << "}^{";
-        sout << sup->printLaTeX(1);
-        sout << "}";
+        out << "_{";
+        inf->printLaTeX(1, out);
+        out << "}^{";
+        sup->printLaTeX(1, out);
+        out << "}";
     }
-    sout << "\\left(";
-    sout << "d" << variables->getName() << "\\cdot";
+    out << "\\left(";
+    out << "d" << variables->getName() << "\\cdot";
     if (argument != CSL_1)
-        sout << argument->printLaTeX(1);
+        argument->printLaTeX(1, out);
     if (not empty)
-        sout << "\\right)";
+        out << "\\right)";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 unique_Expr VectorIntegral::copy_unique() const

--- a/src/csl/pseudoIntegral.h
+++ b/src/csl/pseudoIntegral.h
@@ -204,7 +204,7 @@ class ScalarIntegral: public AbstractIntegral {
             std::ostream &out = std::cout
             ) const override;
 
-    std::string printLaTeX(int mode=0) const override;
+    void printLaTeX(int mode=0, std::ostream &out = std::cout) const override;
 
     unique_Expr copy_unique() const override;
 
@@ -280,7 +280,7 @@ class VectorIntegral: public AbstractIntegral {
             std::ostream &out = std::cout
             ) const override;
 
-    std::string printLaTeX(int mode=0) const override;
+    void printLaTeX(int mode=0, std::ostream &out = std::cout) const override;
 
     unique_Expr copy_unique() const override;
 

--- a/src/csl/tensorField.cpp
+++ b/src/csl/tensorField.cpp
@@ -272,20 +272,18 @@ void TDerivativeElement::printCode(int mode, std::ostream &out) const
     out << ", " << empty << ")";
 }
 
-string TDerivativeElement::printLaTeX(int mode) const
+void TDerivativeElement::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << TensorFieldElement::printLaTeX(max(1, mode));
-    sout << "(";
-    if (not empty or operand != CSL_1)
-        sout << operand->printLaTeX(1);
+    TensorFieldElement::printLaTeX(max(1, mode), out);
     if (not empty)
-        sout << ")";
-    printProp(sout);
+        out << "\\left(";
+    if (not empty or operand != CSL_1)
+        operand->printLaTeX(1, out);
+    if (not empty)
+        out << "\\right)";
+    printProp(out);
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 std::vector<csl::Parent> TDerivativeElement::getSubSymbols() const
@@ -698,20 +696,16 @@ void TensorFieldElement::printCode(int, std::ostream &out) const
         out << ")";
 }
 
-string TensorFieldElement::printLaTeX(int) const
+void TensorFieldElement::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << getLatexName();
-    if (index.size() > 0) {
-        sout << "_";
-        sout << index;
+    TensorElement::printLaTeX(max(1, mode), out);
+    out << "(";
+    out << "{" << point->getLatexName() << "}";
+    out << ")";
+    printProp(out);
+    if (mode == 0) {
+        out << endl;
     }
-    sout << "(";
-    sout << point->getName();
-    sout << ")";
-    printProp(sout);
-
-    return sout.str();
 }
 
 std::vector<csl::Parent> TensorFieldElement::getSubSymbols() const

--- a/src/csl/tensorField.h
+++ b/src/csl/tensorField.h
@@ -227,7 +227,7 @@ class TensorFieldElement: public TensorElement{
             std::ostream& out=std::cout
             ) const override;
 
-    std::string printLaTeX(int mode=0) const override;
+    void printLaTeX(int mode=0, std::ostream &out = std::cout) const override;
 
     std::vector<csl::Parent> getSubSymbols() const override;
 
@@ -295,7 +295,7 @@ class TDerivativeElement: public Operator<TensorFieldElement>{
             std::ostream& out=std::cout
             ) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     std::vector<csl::Parent> getSubSymbols() const override;
 

--- a/src/csl/vector.cpp
+++ b/src/csl/vector.cpp
@@ -78,28 +78,10 @@ void AbstractVectorial::print(int mode, std::ostream &out, LibraryMode) const
         out << endl;
 }
 
-string AbstractVectorial::printLaTeX(int mode) const
+void AbstractVectorial::printLaTeX(int, std::ostream &) const
 {
-    ostringstream sout;
-    if (mode == 0) {
-        if (dim == 1)
-            sout << "Vec";
-        else if (dim == 2)
-            sout << "Mat";
-        else
-            sout << "Tensor";
-    }
-    sout << "{ ";
-    for (int i = 0; i < nArgs; i++) {
-        argument[i]->print(1);
-        if (i < nArgs - 1)
-            sout << " , ";
-    }
-    sout << "}";
-    if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+    print();
+    CALL_SMERROR(CSLError::AbstractCallError);
 }
 
 void AbstractVectorial::printCode(int mode, std::ostream &out) const

--- a/src/csl/vector.h
+++ b/src/csl/vector.h
@@ -56,7 +56,7 @@ class AbstractVectorial: public Abstract{
             std::ostream &out  = std::cout
             ) const override;
 
-    std::string printLaTeX(int mode=0) const override;
+    void printLaTeX(int mode=0, std::ostream &out = std::cout) const override;
 
     std::vector<Parent> getSubSymbols() const override;
 

--- a/src/marty/api/gamma.cpp
+++ b/src/marty/api/gamma.cpp
@@ -3,6 +3,7 @@
 #include "marty/sgl/sgloptions.h"
 
 #include <iostream>
+#include <sstream>
 #include <map>
 #include <set>
 
@@ -249,7 +250,9 @@ static std::string generateLatexImpl(Expr const         &expr,
 
 static std::string generateLatex(csl::Expr const &expr)
 {
-    return expr->printLaTeX(0);
+    std::ostringstream sout;
+    expr->printLaTeX(0, sout);
+    return sout.str();
 }
 
 static std::string generateLatex(sgl::Sum const     *func,

--- a/src/marty/core/feynmanIntegral.cpp
+++ b/src/marty/core/feynmanIntegral.cpp
@@ -2345,18 +2345,21 @@ void FeynmanIntegral::print(int              mode,
         out << '\n';
 }
 
-std::string FeynmanIntegral::printLaTeX(int) const
+void FeynmanIntegral::printLaTeX(int mode, std::ostream &out) const
 {
-    std::ostringstream sout;
-    printLooptoolsId(type, loopToolsId, sout);
+    printLooptoolsId(type, loopToolsId, out);
     if (mty::option::displayIntegralArgs) {
-        sout << "(";
-        for (const auto &arg : argument)
-            sout << arg << ", ";
-        sout << ")";
+        out << "\\left(";
+        for (std::size_t i = 0; i != argument.size(); ++i) {
+            argument[i]->printLaTeX(1, out);
+            if (i + 1 != argument.size()) {
+                out << ",\\ ";
+            }
+        }
+        out << "\\right)";
     }
-
-    return sout.str();
+    if (mode == 0)
+        out << std::endl;
 }
 
 void FeynmanIntegral::printLib(int              mode,

--- a/src/marty/core/feynmanIntegral.h
+++ b/src/marty/core/feynmanIntegral.h
@@ -188,7 +188,7 @@ class FeynmanIntegral : public csl::AbstractMultiFunc {
                csl::LibraryMode libMode
                = csl::LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     void printLib(int mode, csl::LibraryMode libMode, std::ostream &out) const;
 

--- a/src/marty/core/feynruleMomentum.cpp
+++ b/src/marty/core/feynruleMomentum.cpp
@@ -236,14 +236,14 @@ std::ostream &operator<<(std::ostream &out, FeynruleMomentum const &mom)
     out << "Feynman rule mapping for:\n";
     for (size_t i = 0; i != mom.keys.size(); ++i) {
         out << "Key: ";
-        out << mom.keys[i].field.printLaTeX(1);
+        mom.keys[i].field.printLaTeX(1, out);
         out << " , " << mom.keys[i].point->getName();
         if (mom.mapping[i] == -1)
             out << "  not mapped.";
         else {
             out << " mapped to ";
             if (mom.targets[mom.mapping[i]].factor != CSL_1)
-                out << mom.targets[mom.mapping[i]].factor->printLaTeX(1);
+                mom.targets[mom.mapping[i]].factor->printLaTeX(1, out);
             out << mom.targets[mom.mapping[i]].momentum->getName();
             out << "(" << mom.targets[mom.mapping[i]].momentum << ")";
         }

--- a/src/marty/core/graph.cpp
+++ b/src/marty/core/graph.cpp
@@ -1136,7 +1136,9 @@ std::vector<std::shared_ptr<Graph>> Graph::contractionStep() const
     vector<int> connectedContractile = getContractibleConnectedVertices(field);
 
     if constexpr (display) {
-        std::cout << "Contracted field = " << field->printLaTeX(1) << endl;
+        std::cout << "Contracted field = ";
+        field->printLaTeX(1, std::cout);
+        std::cout << endl;
         std::cout << "External options:\n";
         for (const auto &i : extContractile)
             std::cout << i << "  ";

--- a/src/marty/core/propagator.cpp
+++ b/src/marty/core/propagator.cpp
@@ -71,22 +71,19 @@ void Propagator::print(int              mode,
         out << std::endl;
 }
 
-std::string Propagator::printLaTeX(int mode) const
+void Propagator::printLaTeX(int mode, std::ostream &out) const
 {
-    std::ostringstream sout;
-    sout << "Prop(";
-    sout << argument[0]->printLaTeX(1);
-    sout << ", ";
-    sout << argument[1]->printLaTeX(1);
+    out << "\\mathrm{Prop}\\left(";
+    argument[0]->printLaTeX(1, out);
+    out << ",\\ ";
+    argument[1]->printLaTeX(1, out);
     if (argument[2] != CSL_0) {
-        sout << ", ";
-        sout << (argument[2])->printLaTeX(1);
+        out << ", ";
+        argument[2]->printLaTeX(1, out);
     }
-    sout << ")";
+    out << ")";
     if (mode == 0)
-        sout << std::endl;
-
-    return sout.str();
+        out << std::endl;
 }
 
 csl::unique_Expr Propagator::copy_unique() const
@@ -219,19 +216,16 @@ void FermionPropStruct::print(int           mode,
         out << std::endl;
 }
 
-std::string FermionPropStruct::printLaTeX(int mode) const
+void FermionPropStruct::printLaTeX(int mode, std::ostream &out) const
 {
-    std::ostringstream sout;
-    sout << "Fermi(";
-    sout << argument[0]->printLaTeX(1);
-    sout << ", ";
-    sout << argument[1]->printLaTeX(1);
-    sout << ")";
-    sout << "_" << structure;
+    out << "\\mathrm{FermionProp}\\left(";
+    argument[0]->printLaTeX(1, out);
+    out << ", ";
+    argument[1]->printLaTeX(1, out);
+    out << "\\right)";
+    out << "_" << structure;
     if (mode == 0)
-        sout << std::endl;
-
-    return sout.str();
+        out << std::endl;
 }
 
 csl::unique_Expr FermionPropStruct::copy_unique() const

--- a/src/marty/core/propagator.h
+++ b/src/marty/core/propagator.h
@@ -43,7 +43,7 @@ class Propagator : public csl::AbstractMultiFunc {
                csl::LibraryMode libMode
                = csl::LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     csl::unique_Expr copy_unique() const override;
 
@@ -88,7 +88,7 @@ class FermionPropStruct : public csl::AbstractDuoFunc {
                csl::LibraryMode libMode
                = csl::LibraryMode::NoLib) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     csl::unique_Expr copy_unique() const override;
 

--- a/src/marty/core/wick.cpp
+++ b/src/marty/core/wick.cpp
@@ -150,16 +150,13 @@ void Wick::printCode(int mode, std::ostream &out) const
     argument->printCode(mode, out);
 }
 
-string Wick::printLaTeX(int mode) const
+void Wick::printLaTeX(int mode, std::ostream &out) const
 {
-    ostringstream sout;
-    sout << "Wick< ";
-    sout << argument->printLaTeX(1);
-    sout << " >";
+    out << "\\mathrm{T}\\left\\rbrace";
+    argument->printLaTeX(1, out);
+    out << "\\right\\rbrace";
     if (mode == 0)
-        sout << endl;
-
-    return sout.str();
+        out << endl;
 }
 
 optional<csl::Expr> Wick::evaluate(csl::eval::mode) const

--- a/src/marty/core/wick.h
+++ b/src/marty/core/wick.h
@@ -63,7 +63,7 @@ class Wick : public csl::Operator<csl::AbstractFunc> {
 
     void printCode(int mode = 0, std::ostream &out = std::cout) const override;
 
-    std::string printLaTeX(int mode = 0) const override;
+    void printLaTeX(int mode = 0, std::ostream &out = std::cout) const override;
 
     std::optional<csl::Expr> evaluate(csl::eval::mode user_mode
                                       = csl::eval::base) const override;

--- a/tests/system/src/testConjugation.cpp
+++ b/tests/system/src/testConjugation.cpp
@@ -10,6 +10,7 @@
 #include "testutility.h"
 #include <array>
 #include <marty.h>
+#include <sstream>
 
 using namespace csl;
 using namespace mty;
@@ -17,6 +18,13 @@ using namespace mty;
 auto cc(csl::Expr const &expr)
 {
     return GetComplexConjugate(expr);
+}
+
+auto toLatex(csl::Expr const &expr)
+{
+    std::ostringstream sout;
+    expr->printLaTeX(1, sout);
+    return sout.str();
 }
 
 template <size_t N>
@@ -146,29 +154,29 @@ int main()
     loadKinematics<5>(shouldBeS1);
     loadKinematics<5>(shouldBeS2);
 
-    std::cout << (square1->printLaTeX() == shouldBeS1->printLaTeX()) << '\n';
-    std::cout << (square1->printLaTeX() == shouldBeS2->printLaTeX()) << '\n';
-    std::cout << (square2->printLaTeX() == shouldBeS2->printLaTeX()) << '\n';
-    std::cout << (square1->printLaTeX() == shouldBeS2->printLaTeX()) << '\n';
+    std::cout << (toLatex(square1) == toLatex(shouldBeS1)) << '\n';
+    std::cout << (toLatex(square1) == toLatex(shouldBeS2)) << '\n';
+    std::cout << (toLatex(square2) == toLatex(shouldBeS2)) << '\n';
+    std::cout << (toLatex(square1) == toLatex(shouldBeS2)) << '\n';
 
-    if (square1->printLaTeX() != shouldBeS1->printLaTeX()) {
+    if (toLatex(square1) != toLatex(shouldBeS1)) {
         ::error(
             buildMessage("Bad comparison of ", square1, " and ", shouldBeS1));
         return 1;
     }
-    if (square2->printLaTeX() != shouldBeS2->printLaTeX()) {
+    if (toLatex(square2) != toLatex(shouldBeS2)) {
         ::error(
             buildMessage("Bad comparison of ", square2, " and ", shouldBeS2));
         return 1;
     }
-    if (square1->printLaTeX() == shouldBeS2->printLaTeX()) {
+    if (toLatex(square1) == toLatex(shouldBeS2)) {
         ::error(buildMessage("Bad comparison (should be !=) of ",
                              square1,
                              " and ",
                              shouldBeS2));
         return 1;
     }
-    if (square2->printLaTeX() == shouldBeS1->printLaTeX()) {
+    if (toLatex(square2) == toLatex(shouldBeS1)) {
         ::error(buildMessage("Bad comparison (should be !=) of ",
                              square2,
                              " and ",

--- a/tests/units/csl/CMakeLists.txt
+++ b/tests/units/csl/CMakeLists.txt
@@ -1,3 +1,4 @@
 ADD_UNIT_TEST(test_equality)
 ADD_UNIT_TEST(test_numbers)
 ADD_UNIT_TEST(test_literals)
+ADD_UNIT_TEST(test_tolatex)

--- a/tests/units/csl/test_tolatex.cpp
+++ b/tests/units/csl/test_tolatex.cpp
@@ -1,0 +1,46 @@
+
+#include "csltestdata.h"
+#include <csl.h>
+#include <gtest/gtest.h>
+
+TEST(csl_tolatex, simple_scalars)
+{
+    csl::Expr expr = 2*data::a + data::a*data::x;
+    EXPECT_EQ(
+        csl::ToLatex(expr),
+        "2{a}+{a}{x}"
+    );
+}
+
+TEST(csl_tolatex, latex_scalars)
+{
+    csl::Expr a = csl::constant_s("a ; \\alpha");
+    csl::Expr x = csl::variable_s("x ; \\chi");
+    csl::Expr expr = 2*a + a*x;
+    EXPECT_EQ(
+        csl::ToLatex(expr),
+        "2{\\alpha}+{\\alpha}{\\chi}"
+    );
+}
+
+TEST(csl_tolatex, product_1)
+{
+    csl::Expr x = csl::variable_s("x ; \\chi");
+    csl::Expr expr = 2*x*(1 + x*x)/ 3;
+    EXPECT_EQ(
+        csl::ToLatex(expr),
+        "\\frac{2}{3}{\\chi}\\left(1+{\\chi}^{2}\\right)"
+    );
+}
+
+TEST(csl_tolatex, product_2)
+{
+    csl::Expr a = csl::constant_s("a ; \\alpha");
+    csl::Expr b = csl::constant_s("b ; \\beta");
+    csl::Expr x = csl::variable_s("x ; \\chi");
+    csl::Expr expr = 2*a/(2 + x*x) * x / b / 3;
+    EXPECT_EQ(
+        csl::ToLatex(expr),
+        "\\frac{2}{3}\\cdot \\frac{{\\alpha}{\\chi}}{{\\beta}\\left(2+{\\chi}^{2}\\right)}"
+    );
+}


### PR DESCRIPTION
Improvement of the LaTeX output of `csl::Expr` objects. Includes:

- [x] Refactoring of `Expr::printLaTeX()` methods
- [ ] Review index names and ids for latex output
- [ ] Order two-index tensors in chain
- [ ] Adapt existing constant names in `csl` and `marty`