### PR TITLE
Merging the up-to-date compare branch

### DIFF
--- a/src/csl/initSanitizer.h
+++ b/src/csl/initSanitizer.h
@@ -39,23 +39,20 @@ class InitSanitizer {
     {
         this->operator=(t);
     }
-
-    InitSanitizer &operator=(InitSanitizer<T> const &t)
-    {
+    
+    InitSanitizer &operator=(T const &t)
+    {  // Operator already defined before merging "compare"
 #ifdef DEBUG
-        std::cout << "Calling InitSanitizer &operator=(InitSanitizer<T> const &t) on " << name << "\n";
+        std::cout << "Calling InitSanitizer &operator=(T const &t) on " << name << "\n";
 #endif
-        if(t.hasValue())
-        {
-          m_safe=true;
-          m_value=t.get();
-        }
+        m_safe  = true;
+        m_value = t;
         return *this;
-    }
+    }    
 
     template<class U>
     InitSanitizer &operator=(InitSanitizer<U> const &u)
-    {
+    { 
 #ifdef DEBUG
         std::cout << "Calling InitSanitizer &operator=(InitSanitizer<U> const &u) on " << name << "\n";
 #endif
@@ -67,26 +64,6 @@ class InitSanitizer {
         return *this;
     }
     
-    InitSanitizer &operator=(T const &t)
-    {
-#ifdef DEBUG
-        std::cout << "Calling InitSanitizer &operator=(T const &t) on " << name << "\n";
-#endif
-        m_safe  = true;
-        m_value = t;
-        return *this;
-    }
-
-    template<class U>
-    InitSanitizer &operator=(U const &t)
-    {
-#ifdef DEBUG
-        std::cout << "Calling InitSanitizer &operator=(U const &t) on " << name << "\n";
-#endif
-        m_safe  = true;
-        m_value = static_cast<T>(t);
-        return *this;
-    }
 
     bool hasValue() const
     {
@@ -113,22 +90,23 @@ class InitSanitizer {
     }
     
     bool operator == (const InitSanitizer<T> &other) const
-    {
+    {  // Defined in "compare"
       return  (hasValue() && other.hasValue()) ?  (static_cast<T>(get())==static_cast<T>(other.get())) : (!hasValue() && !other.hasValue()) ;
     }
     
     bool operator == (const T &other) const
     {
+      // Defined in "compare"
       return  hasValue() ? (m_value==other) : false;
     }
 
     bool operator != (InitSanitizer<T> &other) const
-    {
+    { // Defined in "compare"
       return  !(*this == other) ;
     }
     
     bool operator != (T &other) const
-    {
+    { // Defined in "compare"
       return  !(*this == other) ;
     }
     

--- a/src/csl/initSanitizer.h
+++ b/src/csl/initSanitizer.h
@@ -72,7 +72,8 @@ class InitSanitizer {
 #ifdef DEBUG
         std::cout << "Calling InitSanitizer &operator=(InitSanitizer<T> const &other) on " << name << "\n";
 #endif
-        this->operator=(other.get());
+        m_safe=other.hasValue();
+        m_value= (m_safe ? other.m_value : m_value);
         return *this;
     }
     

--- a/src/csl/initSanitizer.h
+++ b/src/csl/initSanitizer.h
@@ -51,9 +51,12 @@ class InitSanitizer {
         return *this;
     }    
 
-//     // Delete the default assignment operator
-//     InitSanitizer &operator=(const InitSanitizer<T>&) = delete;
-    
+    // ATTENTION: do NOT define the assignment operator in the following comment.
+    //            In fact, it will conflict to the one uncommented below 
+    //            (i.e. InitSanitizer &operator=(const InitSanitizer<T> &other)).
+    //            By defining them both there will be a warning from -Wdeprecated_copy.
+    //            Alternatively, if one defines only the one with the two templates, then the other 
+    //            is defined by default, and the "name" member WILL be modified.
 //     template<typename U>
 //     InitSanitizer &operator=(const InitSanitizer<U> &other)
 //     { 
@@ -135,14 +138,13 @@ class InitSanitizer {
       return name;
     }
 
-    void setName(const std::string newname) 
+    void setName(const std::string &newname) 
     {
         name=std::move(newname);
     }
   
-  public:
-    std::string name="unnamed_var";
   private:
+    std::string name="unnamed_var";
     T    m_value;
     bool m_safe{false};
 };

--- a/src/csl/initSanitizer.h
+++ b/src/csl/initSanitizer.h
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <iostream>
 #include <exception>
-#include <memory>
 
 namespace csl {
 

--- a/src/csl/librarygroup.cpp
+++ b/src/csl/librarygroup.cpp
@@ -178,7 +178,7 @@ void LibraryGroup::printPrintParameterList(
     out << "})\n";
     out << LibraryGenerator::indent(nIndent) << "{\n";
     out << LibraryGenerator::indent(nIndent + 1)
-        << "out << \"  -> \" << par->name << \": \";\n";
+        << "out << \"  -> \" << par->getName() << \": \";\n";
     out << LibraryGenerator::indent(nIndent + 1) << "if (par->hasValue()) {\n";
     if (complexParameters) {
         out << LibraryGenerator::indent(nIndent + 2)
@@ -204,7 +204,7 @@ void LibraryGroup::printPrintDefinition(std::ostream &out, int nIndent) const
     auto const &[realParams, complexParams]
         = separateComplexParameters(parameters, forcedParameters);
     out << LibraryGenerator::indent(nIndent)
-        << "void print(std::ostream &out = std::cout)\n";
+        << "void print(std::ostream &out = std::cout) const\n";
     out << LibraryGenerator::indent(nIndent) << "{\n";
     out << LibraryGenerator::indent(nIndent + 1)
         << "using real_params = std::array<csl::InitSanitizer<"

--- a/tests/units/csl/test_init_sanitizer.cpp
+++ b/tests/units/csl/test_init_sanitizer.cpp
@@ -4,20 +4,21 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-inline int strcmp(std::string X,std::string Y)
+inline int strcmp(const std::string X,const std::string Y)
 {
-  return (Y==X)? 0 : 1;
+  std::cout << X << " and " << Y << " are" << ( X!=Y ? " not " : " " ) << "equal\n";
+  return (X==Y) ? 0 : 1;
 }
 
 TEST(initSanitizer, create)
 {
     csl::InitSanitizer<int> a;
-    a.name = "a";
-    EXPECT_EQ(strcmp("a", a.name), 0);
+    a.setName("a");
+    EXPECT_EQ(strcmp("a", a.getName()), 0);
     csl::InitSanitizer<float> b("b");
-    EXPECT_EQ(strcmp("b", b.name), 0);
+    EXPECT_EQ(strcmp("b", b.getName()), 0);
     csl::InitSanitizer<float> c("c", 5.5);
-    EXPECT_EQ(strcmp("c", c.name), 0);
+    EXPECT_EQ(strcmp("c", c.getName()), 0);
     EXPECT_EQ(c.get(), 5.5);
 }
 
@@ -97,18 +98,27 @@ TEST(initSanitizer, assign)
     csl::InitSanitizer<int> a("a");
     csl::InitSanitizer<int> a2("a2");
     csl::InitSanitizer<float> b("b", 5.5);
-    EXPECT_EQ(strcmp(a.name, "a"), 0);
-    EXPECT_NE(strcmp(a.name, "a2"), 0);
+    std::cout << "After creation:\n";
+    std::cout << a << " " << a2 << " " << b << "\n";
+    EXPECT_EQ(strcmp(a.getName(), "a"), 0);
+    EXPECT_NE(strcmp(a.getName(), "a2"), 0);
     a = 5;
     a2 = 6;
+    std::cout << "After first assignment:\n";
+    std::cout << a <<  a2 << b << "\n";
     EXPECT_EQ(a, 5);
     a = a2;
+    std::cout << "After second assignment:\n";
+    std::cout << a << a2 <<  b << "\n";
     EXPECT_EQ(a, 6);
     // Check name is not copied
-    EXPECT_EQ(strcmp(a.name, "a"), 0);
-    EXPECT_NE(strcmp(a.name, "a2"), 0);
+    EXPECT_EQ(strcmp(a.getName(), "a"), 0);
+    EXPECT_NE(strcmp(a.getName(), "a2"), 0);
     a = b;
-    EXPECT_EQ(strcmp(a.name, "a"), 0);
+    std::cout << "After third assignment:\n";
+    std::cout << a <<  a2 << b << "\n";
+    EXPECT_EQ(a, 5);
+    EXPECT_EQ(strcmp(a.getName(), "a"), 0);
 }
 
 TEST(initSanitizer, operations)

--- a/tests/units/csl/test_init_sanitizer.cpp
+++ b/tests/units/csl/test_init_sanitizer.cpp
@@ -98,25 +98,33 @@ TEST(initSanitizer, assign)
     csl::InitSanitizer<int> a("a");
     csl::InitSanitizer<int> a2("a2");
     csl::InitSanitizer<float> b("b", 5.5);
+#ifdef DEBUG
     std::cout << "After creation:\n";
     std::cout << a << " " << a2 << " " << b << "\n";
+#endif
     EXPECT_EQ(strcmp(a.getName(), "a"), 0);
     EXPECT_NE(strcmp(a.getName(), "a2"), 0);
     a = 5;
     a2 = 6;
+#ifdef DEBUG
     std::cout << "After first assignment:\n";
     std::cout << a <<  a2 << b << "\n";
+#endif
     EXPECT_EQ(a, 5);
     a = a2;
+#ifdef DEBUG
     std::cout << "After second assignment:\n";
     std::cout << a << a2 <<  b << "\n";
+#endif
     EXPECT_EQ(a, 6);
     // Check name is not copied
     EXPECT_EQ(strcmp(a.getName(), "a"), 0);
     EXPECT_NE(strcmp(a.getName(), "a2"), 0);
     a = b;
+#ifdef DEBUG
     std::cout << "After third assignment:\n";
     std::cout << a <<  a2 << b << "\n";
+#endif
     EXPECT_EQ(a, 5);
     EXPECT_EQ(strcmp(a.getName(), "a"), 0);
 }

--- a/tests/units/csl/test_init_sanitizer.cpp
+++ b/tests/units/csl/test_init_sanitizer.cpp
@@ -127,6 +127,9 @@ TEST(initSanitizer, assign)
 #endif
     EXPECT_EQ(a, 5);
     EXPECT_EQ(strcmp(a.getName(), "a"), 0);
+    a.setName("newname");
+    EXPECT_EQ(strcmp(a.getName(), "newname"), 0);
+    
 }
 
 TEST(initSanitizer, operations)


### PR DESCRIPTION
I fixed the behaviour that was creating "deprecated copy" warnings for the assignment operator in DarkPack. In particular I made 3 changes
1. I leave in the InitSanitizer.h only one assignment operator
2. I made "name" private
3. I defined "param_t::print" as a const method