### PR TITLE
Small improvements to initSantizer

### DIFF
--- a/src/csl/initSanitizer.h
+++ b/src/csl/initSanitizer.h
@@ -142,6 +142,12 @@ class InitSanitizer {
     {
         name=std::move(newname);
     }
+    
+    void print(std::ostream &out)
+    {
+        out << getName() << " = ";
+        (hasValue() ?  (out << get()) : (out << "uninitialized")) << '\n'; 
+    }
   
   private:
     std::string name="unnamed_var";


### PR DESCRIPTION
Other small improvements to the template initSanitizer. I had some misbehaviours in runtime, so I explicitly defined a `print()` method, and inlined some methods.