### PR TITLE
Making lualatex optional

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,6 @@ RUN dnf update -y && \
         g++ \
         gsl \
         gsl-devel \
-        texlive \
         ImageMagick \
         dvipng \
         coreutils \

--- a/.devcontainer/Dockerfile-nografed
+++ b/.devcontainer/Dockerfile-nografed
@@ -11,10 +11,7 @@ RUN dnf update -y && \
         g++ \
         gsl \
         gsl-devel \
-        ImageMagick \
-        dvipng \
         coreutils \
-        texlive \
         qtchooser \
         cmake \
         git \

--- a/.devcontainer/Dockerfile-ubuntu
+++ b/.devcontainer/Dockerfile-ubuntu
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+ARG username=vscode
+
+RUN  apt-get update -y && \
+     apt-get install coreutils build-essential gcc-14 g++-14 gfortran-14 libgsl-dev libgslcblas0 qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools dvipng lcov cmake texlive texlive-latex-extra texlive-luatex imagemagick git -y
+
+RUN useradd ${username}
+
+USER ${username}
+
+ENV CC=gcc-14
+ENV CXX=g++-14
+ENV FC=gfortran-14
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,14 +12,32 @@
 		"dockerfile": "Dockerfile"
 	},
 
+	"initializeCommand": "/bin/sh -lc 'mkdir -p \"${HOME}/.devcontainer\"; target=\"${HOME}/.devcontainer/marty-public.Xauthority\"; if [ -n \"${XAUTHORITY:-}\" ] && [ -f \"${XAUTHORITY}\" ]; then cp \"${XAUTHORITY}\" \"${target}\"; elif [ -f \"${HOME}/.Xauthority\" ]; then cp \"${HOME}/.Xauthority\" \"${target}\"; else : > \"${target}\"; fi'",
+
 	// Custom arguments to pass to the container manager when creating the container from the image
 	"runArgs": [
-		"--userns=keep-id" // <- If you are using Podman container mannager, this  argument is needed to
+		"--userns=keep-id", // <- If you are using Podman container mannager, this  argument is needed to
 		                   //    allow podman containers to have writing permission into the host filesystem
+		"--env=WAYLAND_DISPLAY=${localEnv:WAYLAND_DISPLAY}",
+		"--env=XDG_RUNTIME_DIR=/tmp/runtime-vscode",
+		"--env=DISPLAY=${localEnv:DISPLAY}",
+		"--env=XAUTHORITY=/tmp/.Xauthority"
 	//   "--memory=8g",
 	//   "--memory-swap=10g",
 	//   "--cpus=6"
 	],
+
+	"mounts": [
+		"source=${localEnv:XDG_RUNTIME_DIR}/${localEnv:WAYLAND_DISPLAY},target=/tmp/runtime-vscode/${localEnv:WAYLAND_DISPLAY},type=bind",
+		"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
+		"source=${localEnv:HOME}/.devcontainer/marty-public.Xauthority,target=/tmp/.Xauthority,type=bind"
+	],
+
+	"containerEnv": {
+		"GDK_BACKEND": "wayland,x11",
+		"QT_QPA_PLATFORM": "wayland;xcb",
+		"QT_X11_NO_MITSHM": "1"
+	},
 
 	"customizations": {
 		"vscode": {

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ marty_env.sh
 build 
 Testing
 .directory
+TODO.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ marty_env.sh
 build 
 Testing
 .directory
+.install
 TODO.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 
 project(marty LANGUAGES CXX C Fortran)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 set(GNU_COMPILERS 0)
 set(CLANG_COMPILERS 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ find_package(GSL REQUIRED)
 
 # Dependencies for GRAFED
 find_program(LUALATEX lualatex)
-find_program(CONVERT convert REQUIRED)
-find_program(LATEX latex REQUIRED)
+find_program(CONVERT convert)
+find_program(LATEX latex)
 find_program(DVIPNG dvipng)
 
 if(NOT LUALATEX)
@@ -25,9 +25,9 @@ if(NOT LUALATEX)
 endif()
 
 if(NOT DVIPNG)
-    message(FATAL_ERROR
-        "The 'dvipng' program is not found but necessary for GRAFED."
-        "Install it before retrying the installation.")
+    message(WARNING
+        "The 'dvipng' program is not found."
+        " GRAFED label rendering that relies on latex->dvipng is disabled at runtime.")
 endif()
 
 if(LUALATEX)
@@ -36,11 +36,36 @@ else()
     set(MARTY_HAS_LUALATEX 0)
 endif()
 
+if(CONVERT)
+    set(MARTY_HAS_CONVERT 1)
+else()
+    set(MARTY_HAS_CONVERT 0)
+endif()
+
+if(LATEX)
+    set(MARTY_HAS_LATEX 1)
+else()
+    set(MARTY_HAS_LATEX 0)
+endif()
+
+if(DVIPNG)
+    set(MARTY_HAS_DVIPNG 1)
+else()
+    set(MARTY_HAS_DVIPNG 0)
+endif()
+
 if(NOT CONVERT)
-    message(FATAL_ERROR
-        "The 'convert' program is not found but necessary for GRAFED."
+    message(WARNING
+        "The 'convert' program is not found."
+        " GRAFED PNG export is disabled at runtime."
         "The 'convert' program is part of the ImageMagick package."
-        "Install it before retrying the installation.")
+        "Install it to enable PNG export.")
+endif()
+
+if(NOT LATEX)
+    message(WARNING
+        "The 'latex' program is not found."
+        " GRAFED label rendering that relies on latex->dvipng is disabled at runtime.")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -73,6 +98,9 @@ add_compile_definitions(MARTY_CC=${CMAKE_C_COMPILER})
 add_compile_definitions(MARTY_FC=${CMAKE_Fortran_COMPILER})
 add_compile_definitions(MARTY_INSTALL_PATH=${CMAKE_INSTALL_PREFIX})
 add_compile_definitions(MARTY_HAS_LUALATEX=${MARTY_HAS_LUALATEX})
+add_compile_definitions(MARTY_HAS_CONVERT=${MARTY_HAS_CONVERT})
+add_compile_definitions(MARTY_HAS_LATEX=${MARTY_HAS_LATEX})
+add_compile_definitions(MARTY_HAS_DVIPNG=${MARTY_HAS_DVIPNG})
 
 if((NOT CMAKE_COMPILER_IS_GNUCXX) OR(NOT CMAKE_COMPILER_IS_GNUCC))
     message(WARNING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,15 @@ set(IDENTICAL_COMPILER_VERSION 0)
 find_package(GSL REQUIRED)
 
 # Dependencies for GRAFED
-find_program(LUALATEX lualatex REQUIRED)
+find_program(LUALATEX lualatex)
 find_program(CONVERT convert REQUIRED)
 find_program(LATEX latex REQUIRED)
 find_program(DVIPNG dvipng)
 
 if(NOT LUALATEX)
-    message(FATAL_ERROR
-        "The 'lualatex' program is not found but necessary for GRAFED."
-        "Install it before retrying the installation.")
+    message(WARNING
+        "The 'lualatex' program is not found."
+        " PDF/PNG export features that rely on lualatex are disabled at runtime.")
 endif()
 
 if(NOT DVIPNG)
@@ -30,10 +30,10 @@ if(NOT DVIPNG)
         "Install it before retrying the installation.")
 endif()
 
-if(NOT LUALATEX)
-    message(FATAL_ERROR
-        "The 'lualatex' program is not found but necessary for GRAFED."
-        "Install it before retrying the installation.")
+if(LUALATEX)
+    set(MARTY_HAS_LUALATEX 1)
+else()
+    set(MARTY_HAS_LUALATEX 0)
 endif()
 
 if(NOT CONVERT)
@@ -72,6 +72,7 @@ add_compile_definitions(MARTY_CXX=${CMAKE_CXX_COMPILER})
 add_compile_definitions(MARTY_CC=${CMAKE_C_COMPILER})
 add_compile_definitions(MARTY_FC=${CMAKE_Fortran_COMPILER})
 add_compile_definitions(MARTY_INSTALL_PATH=${CMAKE_INSTALL_PREFIX})
+add_compile_definitions(MARTY_HAS_LUALATEX=${MARTY_HAS_LUALATEX})
 
 if((NOT CMAKE_COMPILER_IS_GNUCXX) OR(NOT CMAKE_COMPILER_IS_GNUCC))
     message(WARNING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 
 project(marty LANGUAGES CXX C Fortran)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 set(GNU_COMPILERS 0)
 set(CLANG_COMPILERS 0)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following procedure is relevant since `MARTY-1.6`. To build and install olde
 
 ### Dependencies
 
-Since `MARTY-1.6` the dependency installations are longer supported by the automated build procedure, it is the user responsibility to install the required dependencies on his/her particular system.
+Since `MARTY-1.6` dependency installation is no longer supported by the automated build procedure; users must install the required dependencies on their system.
 
 Library dependencies (needed at compile-time):
  - `Qt5` (needed for the `GRAFED` Graphical User Interface)
@@ -63,23 +63,23 @@ The corresponding runtime features are disabled automatically in `GRAFED`.
 
  On `Ubuntu` for example, core build dependencies can be installed with
  ``` bash
-     sudo apt-get install libgsl-dev libgslcblas0 coreutils -y
-    sudo apt-get install qtbase5-dev qtbase5-dev-tools qtchooser qt5-qmake -y
-    sudo apt-get install cmake -y
+sudo apt-get install libgsl-dev libgslcblas0 coreutils -y
+sudo apt-get install qtbase5-dev qtbase5-dev-tools qtchooser qt5-qmake -y
+sudo apt-get install cmake -y
  ```
 
  Optional `GRAFED` runtime commands on Ubuntu:
  ``` bash
-     sudo apt-get install texlive texlive-luatex dvipng imagemagick -y
+sudo apt-get install texlive texlive-luatex dvipng imagemagick -y
  ```
  On `MacOS`
  ``` bash
-     brew install coreutils gsl qt@5 gcc@12 cmake
+brew install coreutils gsl qt@5 gcc@12 cmake
  ```
 
  Optional `GRAFED` runtime commands on MacOS:
  ``` bash
-     brew install imagemagick texlive
+brew install imagemagick texlive
  ```
 
 ### Compilers for `MARTY`
@@ -89,16 +89,16 @@ MARTY takes care of compiling and linking `LoopTools` but the compilers must be 
 
 For this reason, the MARTY installation procedure requires to have the GNU compiler collection, version greater than 11. Furthermore, the versions of `gcc/g++/gfortran` should be the same. The minimal set of compilers required to compile `MARTY` is therefore
 ```
-    gcc-11
-    g++-11
-    gfortran-11
+gcc-11
+g++-11
+gfortran-11
 ```
 
 If the default compilers on the system do not meet the above requirements, compilers must be explicitely defined before going further following:
 ``` bash
-    export CXX=g++-11
-    export CC=gcc-11
-    export FC=gfortran-11
+export CXX=g++-11
+export CC=gcc-11
+export FC=gfortran-11
 ```
 
 #### Compiler Compatibility Table
@@ -119,23 +119,23 @@ For a detailed and up-to-date documentation on how to build `MARTY` on these pla
 
 ### Build and install `MARTY`
 
-Once the dependencies have been installed and that the `C`, `C++` and `Fortran` compilers meet the requirements above (either by default or after having exported the `CC`, `CXX` and `FC` environment variables), clone this repository:
+Once the dependencies have been installed and the `C`, `C++`, and `Fortran` compilers meet the requirements above (either by default or after exporting the `CC`, `CXX`, and `FC` environment variables), clone this repository:
 ```bash
-    git clone https://github.com/docbrown1955/marty-public.git
+git clone https://github.com/docbrown1955/marty-public.git
 ```
 Then, build and install `MARTY`!
 ``` bash
-    cd marty-public
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<installation-path-for-marty>
-    make
-    make install
+cd marty-public
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<installation-path-for-marty>
+make
+make install
 ```
 
 If the `CMAKE_INSTALL_PREFIX` is not given, `cmake` will automatically set this variable to `/usr/local`. In case the installation path is not in `/home` (on Unix systems), the installation command requires `sudo`:
 ``` bash
-    sudo make install
+sudo make install
 ```
 
 It is also possible to build `MARTY` in debug mode (without optimization and including debug symbols) using the option `-DCMAKE_BUILD_TYPE=Debug` instead.
@@ -144,11 +144,11 @@ It is also possible to build `MARTY` in debug mode (without optimization and inc
 
 To run the tests simply type:
 ``` bash
-    ctest
+ctest
  ```
 It is possible to get the output of failed tests (e.g. to include in a bug fix request) using
 ``` bash
-    ctest --output-on-failure
+ctest --output-on-failure
 ```
 
 
@@ -157,43 +157,43 @@ It is possible to get the output of failed tests (e.g. to include in a bug fix r
 In case `MARTY` is not installed in a standard location (not in `/usr/local/`) it is necessary to set properly environment variables. Given that the installation path is `<install/path>`, Linux users should add this in their `${HOME}/.bashrc` file:
 
 ``` bash
-    export PATH=$PATH:<install/path>/bin
-    export CPATH=$CPATH:<install/path>/include
-    export C_INCLUDE_PATH=$C_INCLUDE_PATH:<install/path>/include
-    export LIBRARY_PATH=$LIBRARY_PATH:<install/path>/lib
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<install/path>/lib
+export PATH=$PATH:<install/path>/bin
+export CPATH=$CPATH:<install/path>/include
+export C_INCLUDE_PATH=$C_INCLUDE_PATH:<install/path>/include
+export LIBRARY_PATH=$LIBRARY_PATH:<install/path>/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<install/path>/lib
 ```
 
 Although not recommended, if MacOS users install MARTY in a non-standard location the appropriate environment variables are (also to put in `${HOME}/.bashrc`)
 
 ``` bash
-    export PATH=$PATH:<install/path>/bin
-    export CPATH=$CPATH:<install/path>/include
-    export C_INCLUDE_PATH=$C_INCLUDE_PATH:<install/path>/include
-    export LIBRARY_PATH=$LIBRARY_PATH:<install/path>/lib
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:<install/path>/lib
+export PATH=$PATH:<install/path>/bin
+export CPATH=$CPATH:<install/path>/include
+export C_INCLUDE_PATH=$C_INCLUDE_PATH:<install/path>/include
+export LIBRARY_PATH=$LIBRARY_PATH:<install/path>/lib
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:<install/path>/lib
 ```
 
 After the first installation (and adding the environment variables in the `.bashrc` file) it is necessary to launch a new terminal or reload the bash session:
 
 ``` bash
-   source ${HOME}/.bashrc
+source ${HOME}/.bashrc
 ```
 
 ## The specific case of `MacOS`
 
-On `MacOS` the System Integrity Protection (SIP) can cause issues if files are not installed in `/usr/local`. We therefore recommand to install `MARTY` in this location (default):
+On `MacOS`, System Integrity Protection (SIP) can cause issues if files are not installed in `/usr/local`. We therefore recommend installing `MARTY` in this location (default):
 ``` bash
-    mkdir build
-    cd build
-    cmake ..
-    make
-    sudo make install
+mkdir build
+cd build
+cmake ..
+make
+sudo make install
 ```
 
 ## In case of trouble installing `MARTY`
 
-In you have issues to install dependencies or build `MARTY`, please see the open and closed [issues](https://github.com/docbrown1955/marty-public/issues). If not one solves your problem, open a new issue describing the bug:
+If you have issues installing dependencies or building `MARTY`, please see the open and closed [issues](https://github.com/docbrown1955/marty-public/issues). If none solves your problem, open a new issue describing the bug:
  - Which operating system (including the version)
  - Provide a clear description of the procedure followed before the bug happened
  - Copy the error message if any

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ Library dependencies (needed at compile-time):
 System dependencies (needed at run-time as system commands):
  - `cmake`
  - `latex`
- - `lualatex`
  - `dvipng`
  - `convert` (part of `ImageMagick`)
+
+Optional runtime dependency:
+ - `lualatex` (required only for diagram PDF/PNG export paths using tikz-feynman)
 
  On `Ubuntu` for example these dependencies can be installed with
  ``` bash

--- a/README.md
+++ b/README.md
@@ -50,24 +50,36 @@ Library dependencies (needed at compile-time):
  - `Qt5` (needed for the `GRAFED` Graphical User Interface)
  - `GSL` + `GSLCBLAS` (C numerical scientific library)
 
-System dependencies (needed at run-time as system commands):
- - `cmake`
- - `latex`
- - `dvipng`
- - `convert` (part of `ImageMagick`)
+System dependencies:
+ - `cmake` (required at configure/build time)
 
-Optional runtime dependency:
- - `lualatex` (required only for diagram PDF/PNG export paths using tikz-feynman)
+Optional system commands (used by specific `GRAFED` features at runtime):
+ - `latex` + `dvipng` for LaTeX label rendering in diagrams
+ - `lualatex` for PDF export from LaTeX/tikz-feynman
+ - `convert` (from `ImageMagick`) for PNG export from generated PDF
 
- On `Ubuntu` for example these dependencies can be installed with
+If one or several optional commands are missing, `cmake` configuration still succeeds.
+The corresponding runtime features are disabled automatically in `GRAFED`.
+
+ On `Ubuntu` for example, core build dependencies can be installed with
  ``` bash
-    sudo apt-get install libgsl-dev libgslcblas0 texlive texlive-luatex dvipng coreutils imagemagick -y
+     sudo apt-get install libgsl-dev libgslcblas0 coreutils -y
     sudo apt-get install qtbase5-dev qtbase5-dev-tools qtchooser qt5-qmake -y
     sudo apt-get install cmake -y
  ```
+
+ Optional `GRAFED` runtime commands on Ubuntu:
+ ``` bash
+     sudo apt-get install texlive texlive-luatex dvipng imagemagick -y
+ ```
  On `MacOS`
  ``` bash
-    brew install coreutils gsl qt@5 gcc@12 cmake imagemagick texlive
+     brew install coreutils gsl qt@5 gcc@12 cmake
+ ```
+
+ Optional `GRAFED` runtime commands on MacOS:
+ ``` bash
+     brew install imagemagick texlive
  ```
 
 ### Compilers for `MARTY`

--- a/docs/download.html
+++ b/docs/download.html
@@ -143,7 +143,8 @@
 <h2>Build and Install MARTY</h2>
 <p>The following instructions are meant for Ubuntu / Debian and Mac (since 1.1) users. </p>
 <p style="color:orange;">For Windows (for sure) or other Linux distros, the installation script <code>setup.sh</code> may not work ! </p>
-<p> One may however install the dependencies (detailed below), compile the code (this should work on all OS with the required dependencies)
+<p> One may however install the dependencies (detailed below), compile the code (this should work on all OS with the core build dependencies;
+optional runtime commands only affect specific <i>GRAFED</i> features)
 and install the headers and libraries where wanted. Support for Ubuntu &leq;16.04 is available only since 1.2.</p>
 <h3>Building and installing MARTY (Ubuntu / Debian, Mac since 1.1)</h3>
 
@@ -233,14 +234,15 @@ GSL may be installed on Ubuntu/Debian via:</p>
   sudo apt-get install libgsl-dev libgslcblas0
  </code>
 </pre>
-<p><a href="https://www.qt.io/download-open-source">Qt</a> is a C++ framework to create Desktop applications. 
-    <i>GRAFED</i> uses the open-source and free version of Qt. <code>dvipng</code> is a converter
-    from <code>.dvi</code> to <code>.png</code> files allowing <i>GRAFED</i> to compile and 
-    display labels from Latex source. One may install these
-dependencies typing:</p>
+<p><a href="https://www.qt.io/download-open-source">Qt</a> is a C++ framework to create Desktop applications.
+        <i>GRAFED</i> uses the open-source and free version of Qt.
+        Commands such as <code>latex</code> and <code>dvipng</code> are used at runtime to render LaTeX labels,
+        while <code>lualatex</code> and <code>convert</code> (ImageMagick) are used for PDF/PNG export.
+        These commands are optional: if missing, the corresponding <i>GRAFED</i> features are disabled at runtime.
+        One may install these optional commands typing:</p>
 <pre>
  <code>
-  sudo apt-get install qt5-default qtcreator dvipng -y
+    sudo apt-get install qt5-default qtcreator texlive texlive-luatex dvipng imagemagick -y
  </code>
 </pre>
 <p>Finally, <a href="http://www.feynarts.de/looptools/">LoopTools</a>

--- a/src/grafed/core/latexLink.cpp
+++ b/src/grafed/core/latexLink.cpp
@@ -213,14 +213,41 @@ void LatexLinker::write(std::ostream &out)
     out << "\\end{tikzpicture}\n";
 }
 
-void LatexLinker::exportPDF(std::string const &fileName,
+namespace {
+bool commandExists(char const *command)
+{
+    std::string check = std::string("command -v ") + command
+                        + " > /dev/null 2>&1";
+    return system(check.c_str()) == 0;
+}
+}
+
+bool LatexLinker::canExportPDF()
+{
+#if defined(MARTY_HAS_LUALATEX) && MARTY_HAS_LUALATEX == 0
+    return false;
+#endif
+    return commandExists("lualatex");
+}
+
+bool LatexLinker::canExportPNG()
+{
+    return canExportPDF() && commandExists("convert");
+}
+
+bool LatexLinker::exportPDF(std::string const &fileName,
                             std::string const &path)
 {
 #pragma GCC diagnostic ignored "-Wunused-result"
+    if (!canExportPDF()) {
+        std::cerr << "Unable to export PDF: 'lualatex' is not available.\n";
+        return false;
+    }
+
     std::ofstream tex(fileName + ".tex");
     if (not tex) {
         std::cerr << "Unable to create file \"" << fileName << ".tex\".\n";
-        return;
+        return false;
     }
     tex << "\\documentclass[preview]{standalone}\n";
     tex << "\\usepackage{tikz-feynman}\n";
@@ -230,26 +257,58 @@ void LatexLinker::exportPDF(std::string const &fileName,
     tex.close();
     std::string command = "lualatex -interaction=nonstopmode " + fileName
                           + ".tex > /dev/null 2>&1";
-    system(command.c_str());
+    int result = system(command.c_str());
     command = "rm " + fileName + ".tex " + fileName + ".aux " + fileName
               + ".out " + fileName + ".log > /dev/null 2>&1";
     system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PDF: lualatex command failed.\n";
+        return false;
+    }
+
     command = "mv " + fileName + ".pdf " + path + " > /dev/null 2>&1";
-    system(command.c_str());
+    result  = system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PDF: failed to move generated PDF to "
+                  << path << ".\n";
+        return false;
+    }
+
+    return true;
 }
 
-void LatexLinker::exportPNG(std::string const &fileName,
+bool LatexLinker::exportPNG(std::string const &fileName,
                             std::string const &path)
 {
 #pragma GCC diagnostic ignored "-Wunused-result"
+    if (!canExportPNG()) {
+        std::cerr
+            << "Unable to export PNG: required commands are not available.\n";
+        return false;
+    }
+
     std::string pdfName = "tmp_" + fileName;
-    exportPDF(pdfName);
+    if (!exportPDF(pdfName))
+        return false;
+
     std::string command = "convert -density 400 -quality 100% " + pdfName
                           + ".pdf " + fileName + ".png > /dev/null 2>&1";
-    system(command.c_str());
+    int result          = system(command.c_str());
     command = "rm " + pdfName + ".pdf > /dev/null 2>&1; mv " + fileName
               + ".png " + path + "/" + fileName + ".png > /dev/null 2>&1";
-    system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PNG: convert command failed.\n";
+        return false;
+    }
+
+    result = system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PNG: failed to move generated PNG to "
+                  << path << ".\n";
+        return false;
+    }
+
+    return true;
 }
 
 void LatexLinker::removeNode(size_t pos)

--- a/src/grafed/core/latexLink.cpp
+++ b/src/grafed/core/latexLink.cpp
@@ -232,6 +232,9 @@ bool LatexLinker::canExportPDF()
 
 bool LatexLinker::canExportPNG()
 {
+#if defined(MARTY_HAS_CONVERT) && MARTY_HAS_CONVERT == 0
+    return false;
+#endif
     return canExportPDF() && commandExists("convert");
 }
 

--- a/src/grafed/core/latexLink.h
+++ b/src/grafed/core/latexLink.h
@@ -187,9 +187,13 @@ class LatexLinker {
 
     static std::vector<LatexLinker> loadMultiple(std::string const &fileName);
 
-    void exportPDF(std::string const &fileName, std::string const &path = ".");
+    static bool canExportPDF();
 
-    void exportPNG(std::string const &fileName, std::string const &path = ".");
+    static bool canExportPNG();
+
+    bool exportPDF(std::string const &fileName, std::string const &path = ".");
+
+    bool exportPNG(std::string const &fileName, std::string const &path = ".");
 
     void scale(float factor);
 

--- a/src/grafed/gui/diagram.cpp
+++ b/src/grafed/gui/diagram.cpp
@@ -385,13 +385,17 @@ void Diagram::exportSelfPNG(const QString &fileName)
 void Diagram::exportPNG(std::string const &fileName) const
 {
     link.setGraph(getScaledGraph());
-    link.exportPNG(fileName, outputPath);
+    if (!link.exportPNG(fileName, outputPath))
+        std::cerr << "Failed to export PNG for diagram '" << fileName
+                  << "'.\n";
 }
 
 void Diagram::exportPDF(std::string const &fileName) const
 {
     link.setGraph(getScaledGraph());
-    link.exportPDF(fileName, outputPath);
+    if (!link.exportPDF(fileName, outputPath))
+        std::cerr << "Failed to export PDF for diagram '" << fileName
+                  << "'.\n";
 }
 
 std::string Diagram::getLatexSource() const

--- a/src/grafed/gui/latexLink.cpp
+++ b/src/grafed/gui/latexLink.cpp
@@ -213,14 +213,41 @@ void LatexLinker::write(std::ostream &out)
     out << "\\end{tikzpicture}\n";
 }
 
-void LatexLinker::exportPDF(std::string const &fileName,
+namespace {
+bool commandExists(char const *command)
+{
+    std::string check = std::string("command -v ") + command
+                        + " > /dev/null 2>&1";
+    return system(check.c_str()) == 0;
+}
+}
+
+bool LatexLinker::canExportPDF()
+{
+#if defined(MARTY_HAS_LUALATEX) && MARTY_HAS_LUALATEX == 0
+    return false;
+#endif
+    return commandExists("lualatex");
+}
+
+bool LatexLinker::canExportPNG()
+{
+    return canExportPDF() && commandExists("convert");
+}
+
+bool LatexLinker::exportPDF(std::string const &fileName,
                             std::string const &path)
 {
 #pragma GCC diagnostic ignored "-Wunused-result"
+    if (!canExportPDF()) {
+        std::cerr << "Unable to export PDF: 'lualatex' is not available.\n";
+        return false;
+    }
+
     std::ofstream tex(fileName + ".tex");
     if (not tex) {
         std::cerr << "Unable to create file \"" << fileName << ".tex\".\n";
-        return;
+        return false;
     }
     tex << "\\documentclass[preview]{standalone}\n";
     tex << "\\usepackage{tikz-feynman}\n";
@@ -230,26 +257,58 @@ void LatexLinker::exportPDF(std::string const &fileName,
     tex.close();
     std::string command = "lualatex -interaction=nonstopmode " + fileName
                           + ".tex > /dev/null 2>&1";
-    system(command.c_str());
+    int result = system(command.c_str());
     command = "rm " + fileName + ".tex " + fileName + ".aux " + fileName
               + ".out " + fileName + ".log > /dev/null 2>&1";
     system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PDF: lualatex command failed.\n";
+        return false;
+    }
+
     command = "mv " + fileName + ".pdf " + path + " > /dev/null 2>&1";
-    system(command.c_str());
+    result  = system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PDF: failed to move generated PDF to "
+                  << path << ".\n";
+        return false;
+    }
+
+    return true;
 }
 
-void LatexLinker::exportPNG(std::string const &fileName,
+bool LatexLinker::exportPNG(std::string const &fileName,
                             std::string const &path)
 {
 #pragma GCC diagnostic ignored "-Wunused-result"
+    if (!canExportPNG()) {
+        std::cerr
+            << "Unable to export PNG: required commands are not available.\n";
+        return false;
+    }
+
     std::string pdfName = "tmp_" + fileName;
-    exportPDF(pdfName);
+    if (!exportPDF(pdfName))
+        return false;
+
     std::string command = "convert -density 400 -quality 100% " + pdfName
                           + ".pdf " + fileName + ".png > /dev/null 2>&1";
-    system(command.c_str());
+    int result          = system(command.c_str());
     command = "rm " + pdfName + ".pdf > /dev/null 2>&1; mv " + fileName
               + ".png " + path + "/" + fileName + ".png > /dev/null 2>&1";
-    system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PNG: convert command failed.\n";
+        return false;
+    }
+
+    result = system(command.c_str());
+    if (result != 0) {
+        std::cerr << "Unable to export PNG: failed to move generated PNG to "
+                  << path << ".\n";
+        return false;
+    }
+
+    return true;
 }
 
 void LatexLinker::removeNode(size_t pos)

--- a/src/grafed/gui/latexLink.cpp
+++ b/src/grafed/gui/latexLink.cpp
@@ -232,6 +232,9 @@ bool LatexLinker::canExportPDF()
 
 bool LatexLinker::canExportPNG()
 {
+#if defined(MARTY_HAS_CONVERT) && MARTY_HAS_CONVERT == 0
+    return false;
+#endif
     return canExportPDF() && commandExists("convert");
 }
 

--- a/src/grafed/gui/latexLink.h
+++ b/src/grafed/gui/latexLink.h
@@ -187,9 +187,13 @@ class LatexLinker {
 
     static std::vector<LatexLinker> loadMultiple(std::string const &fileName);
 
-    void exportPDF(std::string const &fileName, std::string const &path = ".");
+    static bool canExportPDF();
 
-    void exportPNG(std::string const &fileName, std::string const &path = ".");
+    static bool canExportPNG();
+
+    bool exportPDF(std::string const &fileName, std::string const &path = ".");
+
+    bool exportPNG(std::string const &fileName, std::string const &path = ".");
 
     void scale(float factor);
 

--- a/src/grafed/gui/latexcompiler.cpp
+++ b/src/grafed/gui/latexcompiler.cpp
@@ -14,6 +14,7 @@
 // along with MARTY. If not, see <https://www.gnu.org/licenses/>.
 
 #include "latexcompiler.h"
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <set>
@@ -28,6 +29,26 @@ std::string toString(T const &t)
     std::ostringstream sout;
     sout << t;
     return sout.str();
+}
+
+namespace {
+bool commandExists(char const *command)
+{
+    std::string check = std::string("command -v ") + command
+                        + " > /dev/null 2>&1";
+    return system(check.c_str()) == 0;
+}
+
+bool canRenderLatexLabels()
+{
+#if defined(MARTY_HAS_LATEX) && MARTY_HAS_LATEX == 0
+    return false;
+#endif
+#if defined(MARTY_HAS_DVIPNG) && MARTY_HAS_DVIPNG == 0
+    return false;
+#endif
+    return commandExists("latex") && commandExists("dvipng");
+}
 }
 
 std::string latexcompiler::getGrafedDir()
@@ -49,6 +70,16 @@ std::string latexcompiler::getGrafedDir()
 
 QPixmap latexcompiler::generateLabel(const std::string &texCode)
 {
+    if (!canRenderLatexLabels()) {
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            std::cerr << "GRAFED label rendering disabled: required commands "
+                         "'latex' and/or 'dvipng' are unavailable.\n";
+        }
+        return QPixmap();
+    }
+
     std::string          grafed_dir = getGrafedDir();
     [[maybe_unused]] int res        = system(("mkdir " + grafed_dir).c_str());
     std::ofstream        f(grafed_dir + "/eq.tex");

--- a/src/grafed/gui/mainwindow.cpp
+++ b/src/grafed/gui/mainwindow.cpp
@@ -14,6 +14,7 @@
 // along with MARTY. If not, see <https://www.gnu.org/licenses/>.
 
 #include "mainwindow.h"
+#include "latexLink.h"
 #include "ui_mainwindow.h"
 #include <QCloseEvent>
 
@@ -104,8 +105,8 @@ void MainWindow::setDiagramMode()
         return;
     m_ui->actionSource_to_clipboard->setEnabled(true);
     m_ui->actionSource_Latex->setEnabled(true);
-    m_ui->actionPDF_Latex->setEnabled(true);
-    m_ui->actionPNG_Latex->setEnabled(true);
+    m_ui->actionPDF_Latex->setEnabled(drawer::LatexLinker::canExportPDF());
+    m_ui->actionPNG_Latex->setEnabled(drawer::LatexLinker::canExportPNG());
     m_ui->actionPNG->setEnabled(true);
 
     mainWidget->setDiagramMode();

--- a/src/marty/core/drawer.cpp
+++ b/src/marty/core/drawer.cpp
@@ -52,8 +52,8 @@ drawer::LatexLinker Drawer::buildDiagram(
                         std::string edgeName
                             = (vertices[i][0]->field->isExternal()
                                or vertices[j][0]->field->isExternal())
-                                  ? ""
-                                  : std::string(nodeA->field->getLatexName());
+                                  ? std::string(nodeA->field->getLatexName())
+                                  : "";
                         if (!nodeA->field->isComplexConjugate())
                             link.setParticlesType(i, j, type, edgeName, false);
                         else
@@ -108,8 +108,8 @@ Drawer::buildDiagram(std::shared_ptr<wick::Graph> const &graph,
                         std::string edgeName
                             = (vertices[i][0]->field->isExternal()
                                or vertices[j][0]->field->isExternal())
-                                  ? ""
-                                  : std::string(nodeA->field->getLatexName());
+                                  ? std::string(nodeA->field->getLatexName())
+                                  : "";
                         if (!nodeA->field->isComplexConjugate())
                             link.setParticlesType(
                                 mapping[i], mapping[j], type, edgeName, false);

--- a/src/marty/core/drawer.cpp
+++ b/src/marty/core/drawer.cpp
@@ -283,7 +283,9 @@ void Drawer::exportPNG(std::string const                               &name,
 
     for (size_t i = 0; i != graphs.size(); ++i) {
         auto link = buildDiagram(graphs[i]);
-        link.exportPNG(name + "_" + getName(i), path);
+        if (!link.exportPNG(name + "_" + getName(i), path))
+            std::cerr << "Failed to export PNG for graph index " << i
+                      << ".\n";
     }
 }
 


### PR DESCRIPTION
I edited the CMake configuration to make LualateX and all the dependencies of grafed optional. 
 - All the tests pass (both in containers with and without the optional dependencies)
 - grafed's behaviour has been checked 
 - I fixed a minor bug on grafed (the names of the particles on the legs were not displaying properly)
 - Added Dockerfile with Ubuntu 24.04
 - Edited devcontainer.json to support GUI with Wayland